### PR TITLE
Chainweb hardhat network support

### DIFF
--- a/solidity/contracts/ChainwebChainId.yul
+++ b/solidity/contracts/ChainwebChainId.yul
@@ -1,0 +1,6 @@
+object "ChainwebChainId" {
+  code {
+    mstore(0x0, sload(0x0))
+    return (add(0x0, 0x1c), 0x04)
+  }
+}

--- a/solidity/contracts/SimpleToken.sol
+++ b/solidity/contracts/SimpleToken.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
+import "hardhat/console.sol";
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -53,7 +54,7 @@ contract SimpleToken is ERC20("SimpleToken", "SIM"), Ownable {
 
     /// @notice Precompile that provides the chainweb-chain-id
     address public constant CHAIN_ID_PRECOMPILE =
-        address(0x0000000000000000000000000000000000000422);
+        address(uint160(uint256(keccak256("/Chainweb/Chain/Id/"))));
 
     /// @notice Mapping of chainId to the address of the same contract on other chains
     mapping(uint32 => address) private crossChainAddresses;

--- a/solidity/contracts/SpvPrecompile.yul
+++ b/solidity/contracts/SpvPrecompile.yul
@@ -1,0 +1,13 @@
+object "Echo" {
+  code {
+    let size := calldatasize()
+    // jump to start of free memory
+    let output := 0x80
+
+    // Copy the data to a new buffer in memory
+    calldatacopy(output,0,size)
+
+    // Return the output buffer and its size
+    return(output, size)
+  }
+}

--- a/solidity/contracts/SpvPrecompile.yul
+++ b/solidity/contracts/SpvPrecompile.yul
@@ -1,13 +1,30 @@
 object "Echo" {
   code {
+    // Check that calldatasize is at least 32
     let size := calldatasize()
-    // jump to start of free memory
-    let output := 0x80
+    if lt(size, 0x20) {
+      revert(0,0)
+    }
 
-    // Copy the data to a new buffer in memory
-    calldatacopy(output,0,size)
+    // set proof data size
+    let proof_size := sub(calldatasize(), 0x20)
+
+    // read hash from calldata
+    let expectedHash := calldataload(0x0)
+
+    // Copy the proof data to free memory
+    let offset := 0x80
+    calldatacopy(offset, 0x20, proof_size)
+
+    // compute hash of proof data
+    let actualHash := keccak256(offset, proof_size)
+
+    // enforce equal hashes
+    if iszero(eq(expectedHash, actualHash)) {
+      revert(0,0)
+    }
 
     // Return the output buffer and its size
-    return(output, size)
+    return(offset, proof_size)
   }
 }

--- a/solidity/contracts/mocks/WrongOperationTypeToken.sol
+++ b/solidity/contracts/mocks/WrongOperationTypeToken.sol
@@ -53,7 +53,7 @@ contract WrongOperationTypeToken is ERC20("SimpleToken", "SIM"), Ownable {
 
     /// @notice Precompile that provides the chainweb-chain-id
     address public constant CHAIN_ID_PRECOMPILE =
-        address(0x0000000000000000000000000000000000000422);
+        address(uint160(uint256(keccak256("/Chainweb/Chain/Id/"))));
 
     /// @notice Mapping of chainId to the address of the same contract on other chains
     mapping(uint32 => address) private crossChainAddresses;

--- a/solidity/hardhat.config.js
+++ b/solidity/hardhat.config.js
@@ -1,6 +1,7 @@
 require("@nomicfoundation/hardhat-toolbox");
 require("hardhat-switch-network");
 require("@nomicfoundation/hardhat-verify");
+require("@tovarishfin/hardhat-yul");
 const path = require("path");
 const fs = require("fs");
 
@@ -51,6 +52,14 @@ module.exports = {
   },
   // defaultNetwork: "kadena_devnet0",
   networks: {
+    // This is a "fake" network. It is used only as configuration for
+    // externally managed hardhat nodes.
+    hardhat: {
+      chainId: 1789,
+      accounts: devnetAccounts.accounts.map(account => {
+        return { privateKey: account.privateKey, balance: "1000000000000000000000" }
+      }),
+    },
     kadena_devnet0: {
       url: 'http://localhost:8545',
       chainId: 1789,
@@ -58,12 +67,31 @@ module.exports = {
       chainwebChainId: 0,
     },
     kadena_devnet1: {
-      // url: 'http://localhost:8546',
       url: 'http://localhost:8555',
       chainId: 1790,
       accounts: devnetAccounts.accounts.map(account => account.privateKey),
       chainwebChainId: 1,
     },
+
+    // hardhat networks (one for each chainweb chain)
+    kadena_hardhat0: {
+      url: 'http://localhost:9545',
+      // chainId: 1789,
+      accounts: devnetAccounts.accounts.map(account => account.privateKey),
+      chainwebChainId: 0,
+    },
+    kadena_hardhat1: {
+      url: 'http://localhost:9555',
+      // chainId: 1790,
+      accounts: devnetAccounts.accounts.map(account => account.privateKey),
+      chainwebChainId: 1,
+    },
+  },
+  chainweb: {
+    graph: {
+      0: [1],
+      1: [0],
+    }
   },
   sourcify: {
     enabled: false,

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -23,5 +23,10 @@
         "ts-node": ">=8.0.0",
         "typechain": "^8.3.0",
         "typescript": ">=4.5.0"
+    },
+    "dependencies": {
+        "@tovarishfin/hardhat-yul": "^3.0.5",
+        "async-lock": "^1.4.1",
+        "hardhat-verify": "^1.0.0"
     }
 }

--- a/solidity/test/ChainwebChainId.test.mjs
+++ b/solidity/test/ChainwebChainId.test.mjs
@@ -1,0 +1,19 @@
+import { expect } from "chai";
+import { callChainIdContract, getChainIdContract, getNetworks, withChainweb } from "./utils/utils.js";
+
+import pkg from 'hardhat';
+const { ethers, network } = pkg;
+
+describe("ChainwebChainId Tests", async function () {
+
+  withChainweb();
+
+  it("Should return the chainweb chain id", async function () {
+    for (const netname of getNetworks()) {
+      await switchNetwork(netname);
+      const cid = network.config.chainwebChainId;
+      const a = await callChainIdContract();
+      expect(a).to.equal(cid);
+    }
+  });
+});

--- a/solidity/test/SimpleToken.integration.test.js
+++ b/solidity/test/SimpleToken.integration.test.js
@@ -1,8 +1,7 @@
 const { expect } = require("chai");
 const { ethers, network, switchNetwork } = require("hardhat");
 const { ZeroAddress } = require("ethers");
-const { getSigners, deployContracts, authorizeContracts, crossChainTransfer, initCrossChain, requestSpvProof, redeemCrossChain } = require("./utils/utils");
-
+const { getSigners, deployContracts, authorizeContracts, crossChainTransfer, initCrossChain, requestSpvProof, redeemCrossChain, withChainweb } = require("./utils/utils");
 
 describe("SimpleToken Integration Tests", async function () {
   let signers;
@@ -10,6 +9,8 @@ describe("SimpleToken Integration Tests", async function () {
   let token1;
   let token0Info;
   let token1Info;
+
+  withChainweb();
 
   beforeEach(async function () {
     signers = await getSigners();
@@ -141,14 +142,14 @@ describe("SimpleToken Integration Tests", async function () {
       const receiverBalanceBefore = await token1.balanceOf(receiver.address);
       const redeemerBalanceBefore = await token1.balanceOf(redeemer.address);
 
-      // Transfer 
+      // Transfer
       const origin = await initCrossChain(token0, token0Info, token1Info, sender, receiver, amount);
       const proof = await requestSpvProof(token1Info.chain, origin);
 
       // Third party redeems
       const redeemTx = await token1.connect(redeemer).redeemCrossChain(receiver, amount, proof);
       await redeemTx.wait();
-      
+
       const senderBalanceAfter = await token0.balanceOf(sender.address);
       const receiverBalanceAfter = await token1.balanceOf(receiver.address);
       const recdeemerBalanceAfter = await token1.balanceOf(redeemer.address);
@@ -207,7 +208,7 @@ describe("SimpleToken Integration Tests", async function () {
           fakeProof
         )
       ).to.be.revertedWithCustomError(token1, "SPVVerificationFailed");
-     
+
     });
 
   }); // End of Error Test Cases

--- a/solidity/test/SimpleToken.test.js
+++ b/solidity/test/SimpleToken.test.js
@@ -1,7 +1,7 @@
 const { expect } = require("chai");
 const { ethers, network, switchNetwork } = require("hardhat");
 const { ZeroAddress } = require("ethers");
-const { getSigners, deployContracts, authorizeContracts, initCrossChain, computeOriginHash, requestSpvProof, CrossChainOperation, createTamperedProof, redeemCrossChain, deployMocks } = require("./utils/utils");
+const { getSigners, deployContracts, authorizeContracts, initCrossChain, computeOriginHash, requestSpvProof, CrossChainOperation, createTamperedProof, redeemCrossChain, deployMocks, withChainweb } = require("./utils/utils");
 
 describe("SimpleToken Unit Tests", async function () {
   let signers;
@@ -11,6 +11,8 @@ describe("SimpleToken Unit Tests", async function () {
   let sender;
   let receiver;
   let amount;
+
+  withChainweb();
 
   beforeEach(async function () {
     signers = await getSigners();
@@ -343,7 +345,7 @@ describe("SimpleToken Unit Tests", async function () {
         const token2 = await factory.deploy(ethers.parseEther("1000000"));
         const deploymentTx = token2.deploymentTransaction()
         await deploymentTx.wait();
-     
+
         // Call setCrossChainAddress on token2
         await expect(token2.redeemCrossChain(receiver, amount, proof))
           .to.be.revertedWithCustomError(token1, "IncorrectTargetContract")
@@ -380,7 +382,7 @@ describe("SimpleToken Unit Tests", async function () {
       it("Should revert if authorized source contract does not match origin contract address", async function () {
         // Generate a random Ethereum address
         const randomAddress = ethers.Wallet.createRandom().address;
-    
+
         const tx = await token1.setCrossChainAddress(token0Info.chain, randomAddress);
         await tx.wait();
         await expect(token1.redeemCrossChain(receiver, amount, proof))
@@ -467,11 +469,4 @@ describe("SimpleToken Unit Tests", async function () {
     }); // End of Success Test Cases
   }); // End of getCrossChainAddress
 }); // End of SimpleToken Unit Tests
-
-
-
-
-
-
-
 

--- a/solidity/test/utils/chainweb.mjs
+++ b/solidity/test/utils/chainweb.mjs
@@ -29,7 +29,7 @@ export const CHAIN_ID_ABI = ['function chainwebChainId() view returns (uint32)']
 // FIXME this address is at risk of conflicting with future Ethereum upgrades
 // Instead uses something like address(keccak256("/Chainweb/KIP-34/VERIFY/SVP/"))
 export const VERIFY_ADDRESS = "0x0000000000000000000000000000000000000421";
-export const VERIFY_BYTE_CODE = "0x365f608037366080f3"
+export const VERIFY_BYTE_CODE = "0x60203610601f5736601f1901806020608037806080205f3503601f576080f35b5f80fd"
 export const VERIFY_ABI = ['function verify(bytes memory proof) public pure returns (bytes memory data)']
 
 /* *************************************************************************** */
@@ -441,6 +441,8 @@ export async function getSpvProof(trgChain, origin) {
   });
 
   const params = 'tuple(uint32,address,uint64,bytes,tuple(uint32,address,uint64,uint64,uint64))'
-  return coder.encode([params], [xmsg]);
+  const payload = coder.encode([params], [xmsg]);
+  const hash = ethers.keccak256(payload)
+  return ethers.concat([hash, payload])
 }
 

--- a/solidity/test/utils/chainweb.mjs
+++ b/solidity/test/utils/chainweb.mjs
@@ -1,0 +1,446 @@
+import pkg from 'hardhat';
+const { ethers } = pkg;
+
+import { styleText } from 'node:util';
+import AsyncLock from 'async-lock';
+import { spawn } from 'child_process';
+
+/* *************************************************************************** */
+/* TODO */
+
+// * Add some sanity check to SpvProofs that detects tampering (e.g. HMAC)
+// * implement proper delay until SPV proof become available
+// * install mining trigger that listens on SPV requests
+// * support graphs that include non-evm chains (by just skipping over them)
+// * Consider deploying the spv precompile at an hash address that won't colide
+//   with future Ethereum extensions.
+// * Use mocha root hooks to manage hardhat network
+// * move all of this into a hardhat-plugin
+// * Make logging verbosity configurable
+// * Manage hardhat ports internally
+
+/* *************************************************************************** */
+/* Network Constants */
+
+export const CHAIN_ID_BYTE_CODE = "0x5f545f526004601cf3"
+export const CHAIN_ID_ADDRESS = ethers.dataSlice(ethers.id("/Chainweb/Chain/Id/"), 12);
+export const CHAIN_ID_ABI = ['function chainwebChainId() view returns (uint32)'];
+
+// FIXME this address is at risk of conflicting with future Ethereum upgrades
+// Instead uses something like address(keccak256("/Chainweb/KIP-34/VERIFY/SVP/"))
+export const VERIFY_ADDRESS = "0x0000000000000000000000000000000000000421";
+export const VERIFY_BYTE_CODE = "0x365f608037366080f3"
+export const VERIFY_ABI = ['function verify(bytes memory proof) public pure returns (bytes memory data)']
+
+/* *************************************************************************** */
+/* Logging */
+
+// TODO: should we use a logging library like winston or pino or would that make
+// this code to opinionated?
+
+function logInfo(color, label, msg) {
+  console.log(styleText(color, `[hardhat ${label}]`), msg);
+}
+
+function logError(color, label, msg) {
+  console.error(styleText(color, `[hardhat ${label}]`), msg);
+}
+
+/* *************************************************************************** */
+/* Utils */
+
+function sleep(ms, logFun) {
+  return new Promise((resolve) => {
+    logFun(`Sleeping for ${ms} milliseconds`);
+    setTimeout(resolve, ms);
+  });
+}
+
+function wordToAddress(hexbytes) {
+  return ethers.getAddress(ethers.dataSlice(hexbytes,12))
+}
+
+/* *************************************************************************** */
+/* Ethers Provider */
+
+function getProvider(rpcUrl) {
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  provider.pollingInterval = 100;
+  return provider;
+
+  // would be nice to use this to subscribe to pending txs. But that seems to be
+  // not reliable.
+  // return new ethers.providers.WebSocketProvider(rpcUrl);
+}
+
+/* *************************************************************************** */
+/* Run Hardhat Network */
+
+function streamLogger(stream, logFun) {
+  let buffer = "";
+  stream.on('data', (data) => {
+    const parts = (buffer + data).split(/\r?\n/);
+    for (const line of parts.slice(0,-1)) {
+        logFun(line);
+    }
+    buffer = parts.slice(-1).join()
+  });
+  return buffer;
+}
+
+async function runHardhatNetwork(port, logger) {
+    const child = spawn('npx', ['hardhat', 'node', '--port', port],{
+      detached: false, // FIXME not sure why this does not work as it should ...
+    });
+
+    const stdoutBuffer = streamLogger(child.stdout, logger.info);
+    const stderrBuffer = streamLogger(child.stderr, logger.error);
+
+    child.on('close', (exitCode) => {
+      if (stdoutBuffer.length > 0) {
+        logger.info(stdoutBuffer);
+      }
+      if (stderrBuffer.length > 0) {
+        logger.error(stderrBuffer);
+      }
+      if (exitCode === null) {
+        logger.info(`terminated with code ${exitCode}`);
+      } else if (exitCode != 0) {
+        logger.error(`failed with code ${exitCode}`);
+        throw new Error(`hardhat ${port} failed with code ${exitCode}`);
+      }
+    });
+
+    await new Promise((resolve, reject) => {
+      child.on('spawn', resolve);
+    });
+
+    // FIXME wait for proper messages and return an event if this triggered
+    // actually, we may just block runHardHatNetwork until it's ready...
+    await sleep(2000, logger.info);
+    return child;
+}
+
+/* *************************************************************************** */
+/* Chain */
+
+const CHAIN_COLORS = ['cyan', 'yellow', 'magenta', 'blue', 'green', 'red'];
+
+const lock = new AsyncLock();
+
+class Chain {
+
+  constructor(config) {
+    const cid = config.chainwebChainId;
+    this.config = config;
+
+    this.logger = {
+      info: (msg) => logInfo(CHAIN_COLORS[cid], cid, msg),
+      error: (msg) => logError(CHAIN_COLORS[cid], cid, msg),
+    };
+
+    // set when the chain is added to the chainweb
+    this.adjacents = null;
+
+    // set when the hardhat network process is started
+    this.process = null;
+
+    // set when the ethers provider is created
+    this.provider = null;
+
+    // set when automining is enabled
+    this.autominer = null;
+  }
+
+  get cid() {
+    return this.config.chainwebChainId;
+  }
+
+  get url() {
+    return this.config.url;
+  }
+
+  get port() {
+    const url = new URL(this.url);
+    return url.port ? parseInt(url.port, 10) : 8454;
+  }
+
+  async getBlockNumber() {
+    return await this.provider.getBlockNumber()
+  }
+
+  async makeBlock() {
+    return await this.provider.send("evm_mine", []);
+  }
+
+  async mine () {
+    await lock.acquire('mine', async () => {
+        this.logger.info(`mining requested`);
+        await this._mine();
+    });
+  }
+
+  async _mine () {
+    const cn = await this.getBlockNumber();
+    this.logger.info(`current height is ${cn}`);
+    for (const a of this.adjacents) {
+      const an = await a.getBlockNumber();
+      if (an < cn) {
+          await a._mine();
+      }
+    }
+    this.logger.info(`make new block`);
+    const resp = await this.makeBlock();
+  }
+
+  async hasPending () {
+    const ps = await this.provider.send(
+      "eth_getBlockTransactionCountByNumber",
+      ["pending"]
+    );
+    return ps > 0;
+  }
+
+  async runPending () {
+    const pending = await this.hasPending()
+    if (pending) {
+        await this.mine();
+    }
+  }
+
+  async initializeCidContract () {
+    await this.provider.send(
+      "hardhat_setCode",
+      [CHAIN_ID_ADDRESS, CHAIN_ID_BYTE_CODE]
+    );
+    const hex = "0x" + this.cid.toString(16).padStart(64, '0');
+    await this.provider.send(
+      "hardhat_setStorageAt",
+      [CHAIN_ID_ADDRESS, "0x0", hex]
+    );
+  }
+
+  async initializeVerificationPrecompile() {
+    await this.provider.send(
+      "hardhat_setCode",
+      [VERIFY_ADDRESS, VERIFY_BYTE_CODE]
+    );
+  }
+
+  async enableAutomine () {
+    if (!this.autominer) {
+      this.autominer = setInterval(() => this.runPending(), 100);
+      this.logger.info(`Automine enabled`);
+    }
+  }
+
+  async disableAutomine() {
+    if (this.autominer) {
+      clearInterval(this.autominer);
+      this.autominer = null;
+      this.logger.info(`Automine disabled`);
+    }
+  }
+
+  async startHardhatNetwork() {
+    if (this.process) {
+      this.logger.error("Hardhat network is already running");
+    } else {
+      this.logger.info(`starting chain network at port ${this.port}`);
+      this.process = await runHardhatNetwork(this.port, this.logger)
+      this.logger.info(`started network at port ${this.port}`);
+    }
+  }
+
+  async stopHardhatNetwork () {
+    this.logger.info("stopping hardhat network");
+    if (this.process) {
+      await this.process.kill();
+      this.logger.info("stopped hardhat network");
+      this.process = null;
+    } else {
+      this.logger.error("no hardhat network process found");
+    }
+  }
+
+  async start () {
+    // start hardhat network
+    await this.startHardhatNetwork();
+
+    // create provider
+    this.provider = await getProvider(this.url);
+
+    // initialize system contracts
+    await this.initializeCidContract();
+    await this.initializeVerificationPrecompile();
+
+    // setup automining
+    await this.provider.send("evm_setAutomine", [false]);
+    await this.enableAutomine()
+  }
+
+  async stop () {
+    this.disableAutomine();
+    this.provider = null;
+    this.stopHardhatNetwork();
+  }
+}
+
+/* *************************************************************************** */
+/* Chainweb Network */
+
+function makeChainweb(logger) {
+
+  const graph = hre.config.chainweb.graph;
+  const networks = hre.config.networks;
+
+  // Create Indiviual Chains
+  logger.info("creating chains");
+  const chains = {};
+  for (const k in networks) {
+    if (k.includes('kadena_hardhat')) {
+      const config = networks[k];
+      chains[config.chainwebChainId] = new Chain(config);
+    }
+  }
+
+  // Put Chains into the Chainweb Graph
+  logger.info("integrating chains into Chainweb");
+  for (const c in chains) {
+    chains[c].adjacents = graph[c].map(x => {
+      const a = chains[x];
+      if (a === undefined) {
+        throw new Error(`Missing configuration for chain ${x}`);
+      }
+      return chains[x]
+    });
+  }
+  return chains;
+}
+
+class Network {
+  constructor() {
+    this.logger = {
+      info: (msg) => logInfo('reset', '-', msg),
+      error: (msg) => logError('reset', '-', msg),
+    };
+    this.chains = makeChainweb(this.logger);
+  }
+
+  getProvider(cid) {
+    const chain = this.chains[cid];
+    if (chain === undefined) {
+      throw new Error("Chain not found in Chainweb", cid);
+    }
+    const provider = chain.provider;
+    if (provider === null) {
+      throw new Error("Chain network is not running", cid);
+    }
+    return provider;
+  }
+
+  async start () {
+    try {
+      this.logger.info("Starting chain networks");
+      await Promise.all(
+        Object.values(this.chains).map((chain) => {
+            return chain.start()
+        })
+      );
+      this.logger.info("Chainweb chains initialized");
+    } catch (e) {
+      this.logger.error(`Failure while starting networks: ${e}, ${e.stack}`);
+      await this.stop ();
+    }
+  }
+
+  async stop () {
+    this.logger.info("Stopping chain networks");
+    await Promise.all(
+      Object.values(this.chains).map((chain) => chain.stop())
+    );
+    this.logger.info("Stopped chain networks");
+  }
+}
+
+/* *************************************************************************** */
+/* Network Interface */
+
+const network = new Network();
+let userCount = 0;
+
+export async function startHardhatNetwork () {
+  userCount += 1;
+  if (userCount == 1) {
+    await network.start();
+  }
+}
+
+export async function stopHardhatNetwork () {
+  userCount -= 1;
+  if (userCount == 0) {
+    const r = await network.stop();
+    return r;
+  }
+}
+
+/* *************************************************************************** */
+/* SPV */
+
+// Mock getProof:
+//
+// Call our chainweb SPV api with the necesasry proof parameters
+//
+export async function getSpvProof(trgChain, origin) {
+  // return fetch(
+  //   `http://localhost:1848/chainweb/0.0/evm-development/chain/${trgChain}/spv/chain/${origin.chain}/height/${origin.height}/transaction/${origin.txIdx}/event/${origin.eventIdx}`
+  // );
+
+  // get origin chain
+  const provider = network.getProvider(origin.chain);
+
+  // Query Event information from origin chain
+  const blockLogs = await provider.getLogs({
+    fromBlock: origin.height,
+    toBlock: origin.height,
+  });
+
+  const txLogs = blockLogs.filter((l) => l.transactionIndex == origin.txIdx);
+  const log = txLogs[origin.eventIdx];
+  if (log === undefined || log.removed) {
+    throw new Error("No log entry found at origin", origin);
+  }
+
+  const topics = log.topics;
+
+  if (topics.length != 4) {
+    throw new Error(`Expected exactly four topics at origin, but got ${topcis.length}`, origin);
+  }
+
+  const coder = ethers.AbiCoder.defaultAbiCoder();
+
+  // FIXME: double check the event signature
+  // TODO: add and hash or HMAC as mock proof
+
+  // (uint32,address,uint64,uint64,uint64)
+  const xorigin = Object.values({
+    chainId: origin.chain,
+    address: log.address,
+    height: origin.height,
+    txIdx: origin.txIdx,
+    eventIdx: origin.eventIdx,
+  });
+
+  // (uint32,address,uint64,(uint32,address,uint64,uint64,uint64))
+  const xmsg = Object.values ({
+    trgChainId: ethers.toNumber(topics[1]),
+    trgAddress: wordToAddress(topics[2]),
+    opType: ethers.toNumber(topics[3]),
+    data: coder.decode(['bytes'], log.data)[0],
+    origin: xorigin,
+  });
+
+  const params = 'tuple(uint32,address,uint64,bytes,tuple(uint32,address,uint64,uint64,uint64))'
+  return coder.encode([params], [xmsg]);
+}
+

--- a/solidity/test/utils/utils.js
+++ b/solidity/test/utils/utils.js
@@ -41,7 +41,6 @@ async function callChainIdContract () {
   ]);
   return parseInt(hex, 16);
 }
->>>>>>> 3b9aa16 (WIP: experimental Chainweb hardhat network support)
 
 async function getSigners() {
   await switchNetwork(`${NETWORK_STEM}0`);

--- a/solidity/test/utils/utils.js
+++ b/solidity/test/utils/utils.js
@@ -1,11 +1,50 @@
 const { ethers, network, switchNetwork } = require("hardhat");
+const { getSpvProof, startHardhatNetwork, stopHardhatNetwork, CHAIN_ID_ADDRESS, CHAIN_ID_ABI  } = require('./chainweb.mjs');
 
 // hash of CrossChainInitialized(uint32,address,uint64,bytes)
 const EVENT_SIG_HASH =
-  "0x9d2528c24edd576da7816ca2bdaa28765177c54b32fb18e2ca18567fbc2a9550";
+  "0x9d2528c24edd576da7816ca2bdaa28765177c54b32fb18e2ca18567fbc2a9550"
+
+const NETWORK_STEM = process.env.NETWORK_STEM || "kadena_hardhat";
+
+function getNetworks() {
+  return Object
+    .keys(hre.config.networks)
+    .filter(net => net.includes(NETWORK_STEM));
+}
+
+function usesHardhatNetwork () {
+  return (NETWORK_STEM == "kadena_hardhat");
+}
+
+function withChainweb() {
+  if (usesHardhatNetwork()) {
+    before(async function () {
+      await startHardhatNetwork()
+    });
+
+    after(async function () {
+      await stopHardhatNetwork()
+    });
+  }
+}
+
+function getChainIdContract () {
+  return new ethers.Contract(CHAIN_ID_ADDRESS, CHAIN_ID_ABI, ethers.provider);
+}
+
+async function callChainIdContract () {
+  const hex = await ethers.provider.send("eth_call", [
+    { to: CHAIN_ID_ADDRESS },
+    'latest',
+    {},
+  ]);
+  return parseInt(hex, 16);
+}
+>>>>>>> 3b9aa16 (WIP: experimental Chainweb hardhat network support)
 
 async function getSigners() {
-  await switchNetwork("kadena_devnet0");
+  await switchNetwork(`${NETWORK_STEM}0`);
   const [deployer, alice, bob, carol] = await ethers.getSigners();
   return {
     deployer,
@@ -16,9 +55,7 @@ async function getSigners() {
 }
 
 async function deployContracts() {
-  const networks = Object.keys(hre.config.networks).filter((net) =>
-    net.includes("kadena_devnet")
-  );
+  const networks = getNetworks();
   console.log(
     `Found ${networks.length} Kadena devnet networks: ${networks.join(", ")}`
   );
@@ -65,9 +102,7 @@ async function deployContracts() {
 }
 
 async function deployMocks() {
-  const networks = Object.keys(hre.config.networks).filter((net) =>
-    net.includes("kadena_devnet")
-  );
+  const networks = getNetworks();
   console.log(
     `Found ${
       networks.length
@@ -196,11 +231,17 @@ async function getProof(trgChain, origin) {
 
 // Request cross-chain transfer SPV proof
 async function requestSpvProof(targetChain, origin) {
-  const spvCall = await getProof(targetChain, origin);
-  const proof = await spvCall.json();
-  const proofStr = JSON.stringify(proof);
-  const hexProof = "0x" + Buffer.from(proofStr, "utf8").toString("hex");
-  return hexProof;
+  if (usesHardhatNetwork()) {
+    const hexProof = await getSpvProof(targetChain, origin);
+    console.log(`Hex proof: ${hexProof}`);
+    return hexProof;
+  } else {
+    const spvCall = await getProof(targetChain, origin);
+    const proof = await spvCall.json();
+    const proofStr = JSON.stringify(proof);
+    const hexProof = "0x" + Buffer.from(proofStr, "utf8").toString("hex");
+    return hexProof
+  }
 }
 
 async function createTamperedProof(targetChain, origin) {
@@ -279,5 +320,8 @@ module.exports = {
   createTamperedProof,
   CrossChainOperation,
   deployMocks,
+  getChainIdContract,
+  getNetworks,
+  withChainweb,
+  callChainIdContract,
 };
-


### PR DESCRIPTION
This PR provides hardhat networks with automining that simulates a Chainweb braiding.

### Usage

```sh
export NETWORK_STEM=kadena_hardhat
npx hardhat test
```

To switch back to the chainweb-node devnet:

```sh
export NETWOKR_STEM=kadena_devnet
```

To use this branch with chainweb-node devnet you need to run `./network devnet pull` for the latest (backward compatible) chainweb-node image. 

### Tasks

* [x] Run hardhat networks for each chain as standalone processes:
* [x] Configure networks with same allocations as chainweb-node evm-devnet
* [x] disable hardhat single-chain automining
* [x] implement automining that honors Chainweb braiding invariants
* [x] implement SPV mock precompile
* [x] implement API for generating mock SPV proofs 
* [x] let SPV proof creation respect chainweb braiding.
* [x] add simple consistency checks to mock SPV proofs to catch simple tampering (e.g. Hash or HMAC)
* [ ] pick an address for SPV precompile that avoids future conflicts with Ethereum upgrades.
* [x] simplify implementation of `chainwebChainId` system contract
* [ ] move implementation into hardhat plugin with a proper configuration and UX concept
* [ ] make verbosity of Hardhat Network tracing configurable.
* [ ] use mocha root hooks to manage Hardhat Networks more efficiently.

Currently, automining is triggered via frequent polling of pending transactions which is not ideal. However, subscribing to the pending transactions event stream was not reliable. We should investigate why this did not work as expected.