### PR TITLE
Fix typo in test and add indexed to a param in event CrossChainCompleted

### DIFF
--- a/solidity/contracts/SimpleToken.sol
+++ b/solidity/contracts/SimpleToken.sol
@@ -77,7 +77,7 @@ contract SimpleToken is ERC20("SimpleToken", "SIM"), Ownable {
      * @dev Emitted for any cross chain transaction
      */
     event CrossChainCompleted(
-        uint64 crossChainOperationType,
+        uint64 indexed crossChainOperationType,
         bytes crossChainData,
         CrossChainOrigin origin
     );
@@ -113,7 +113,7 @@ contract SimpleToken is ERC20("SimpleToken", "SIM"), Ownable {
         address originContractAddress,
         address knownOriginContractAddress
     );
-  
+
     error IncorrectReceiver(address crossChainReceiver, address receiver);
     error IncorrectAmount(uint256 crossChainValue, uint256 amount);
 

--- a/solidity/test/SimpleToken.test.js
+++ b/solidity/test/SimpleToken.test.js
@@ -334,7 +334,7 @@ describe("SimpleToken Unit Tests", async function () {
           .withArgs(token1Info.chain, token0Info.chain);
       });
 
-      it("Should revert when redeeming on the wrong contrct", async function () {
+      it("Should revert when redeeming on the wrong contract", async function () {
         // Switch to chain1, where token1 is deployed
         await switchNetwork(token1Info.network.name);
 
@@ -343,7 +343,7 @@ describe("SimpleToken Unit Tests", async function () {
         const token2 = await factory.deploy(ethers.parseEther("1000000"));
         const deploymentTx = token2.deploymentTransaction()
         await deploymentTx.wait();
-     
+
         // Call setCrossChainAddress on token2
         await expect(token2.redeemCrossChain(receiver, amount, proof))
           .to.be.revertedWithCustomError(token1, "IncorrectTargetContract")
@@ -380,7 +380,7 @@ describe("SimpleToken Unit Tests", async function () {
       it("Should revert if authorized source contract does not match origin contract address", async function () {
         // Generate a random Ethereum address
         const randomAddress = ethers.Wallet.createRandom().address;
-    
+
         const tx = await token1.setCrossChainAddress(token0Info.chain, randomAddress);
         await tx.wait();
         await expect(token1.redeemCrossChain(receiver, amount, proof))


### PR DESCRIPTION
While doing a last update of the KIP, I noticed a typo in a test. I also noticed that the `crossChainOperationType` in the `CrossChainCompleted` was not indexed, while it is in the `CrossChainInitialized` event. This PR fixes thos things