### PR TITLE
Remove typescript from hardhat.config.js and package.json

### DIFF
--- a/solidity/hardhat.config.js
+++ b/solidity/hardhat.config.js
@@ -15,7 +15,6 @@ if (devnetAccounts.accounts.length !== requiredAccounts) {
   throw new Error(`Expected ${requiredAccounts} accounts in devnet-accounts.json, found ${devnetAccounts.accounts.length}`);
 };
 
-/** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
   solidity: {
     compilers: [

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -10,18 +10,11 @@
         "@nomicfoundation/hardhat-verify": "^2.0.12",
         "@nomicfoundation/ignition-core": "^0.15.9",
         "@openzeppelin/contracts": "^5.2.0",
-        "@typechain/ethers-v6": "^0.5.0",
-        "@typechain/hardhat": "^9.0.0",
-        "@types/chai": "^4.2.0",
-        "@types/mocha": ">=9.1.0",
         "chai": "^4.2.0",
         "ethers": "^6.4.0",
         "hardhat": "^2.22.18",
         "hardhat-gas-reporter": "^1.0.8",
         "hardhat-switch-network": "^1.2.0",
-        "solidity-coverage": "^0.8.1",
-        "ts-node": ">=8.0.0",
-        "typechain": "^8.3.0",
-        "typescript": ">=4.5.0"
+        "solidity-coverage": "^0.8.1"
     }
 }


### PR DESCRIPTION
This PR updates the hardhat config file and package. json to remove typescript since typescript is not being used in this example project.