### PR TITLE
Change sandbox blockscout URLs to http (again)

### DIFF
--- a/solidity/.env.example
+++ b/solidity/.env.example
@@ -1,6 +1,2 @@
 # PK of the deployer account
 DEPLOYER_PRIVATE_KEY=0x0000000000000000000000000000000000000000000000000000000000000000
-
-# To avoid self-signed certificate errors in Node.js
-# This is not recommended for production environments.
-NODE_TLS_REJECT_UNAUTHORIZED=0

--- a/solidity/hardhat.config.js
+++ b/solidity/hardhat.config.js
@@ -41,8 +41,8 @@ module.exports = {
       externalHostUrl: "http://localhost:1848/chainweb/0.0/evm-development",
        etherscan: {
         apiKey: 'abc', // Any non-empty string works for Blockscout
-        apiURLTemplate: 'https://chain-{cid}.evm.kadena.internal:8000/api/',
-        browserURLTemplate: 'https://chain-{cid}.evm.kadena.internal:8000/',
+        apiURLTemplate: 'http://chain-{cid}.evm.kadena.internal:8000/api/',
+        browserURLTemplate: 'http://chain-{cid}.evm.kadena.internal:8000/',
       },
     },
     testnet: {


### PR DESCRIPTION
Somehow, the Blockscout URLs in hardat.config.js got changed back to https in the last merge. This PR changes them back to http. This has been tested after branching off latest main with sandbox set to default to http