### PR TITLE
Integration of nethermind

### DIFF
--- a/devnet/chain-specs/chain-spec-20.json
+++ b/devnet/chain-specs/chain-spec-20.json
@@ -1,1 +1,167 @@
-{"alloc":{"0x0000F90827F1C53a10cb7A02335B175320002935":{"balance":"0x0","code":"0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500"},"0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02":{"balance":"0x0","code":"0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"},"0x03e95Af0fC4971EdCa12E6d2d1540c28314d15d5":{"balance":"0xd3c21bcecceda1000000"},"0x28f2d8ef4e0fe6B2E945cF5C33a0118a30a62354":{"balance":"0xd3c21bcecceda1000000"},"0x33018A42499f10B54d9dBCeBB71831C805D64cE3":{"balance":"0xd3c21bcecceda1000000"},"0x3492DA004098d728201fD82657f1207a6E5426bd":{"balance":"0xd3c21bcecceda1000000"},"0x47fAE86F6416e6115a80635238AFd2F18D69926B":{"balance":"0xd3c21bcecceda1000000"},"0x49eed2ac33f09e931bd660f0168417b9614485b6":{"balance":"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","code":"0x346101535773ad9923c37370bcbcf00ed194506d8950848956965f9060209160c060e091610140946101609061018091609a9660e3360361014c575f359860203560f01c9360223560ea1c9860263560601c9a603a3599605a359b607a359a5f60db3560c01c9a03610145576004815f80739b02c3e2df42533e0fd166798b5a616f59dbd2cc5afa1561013e5751036101375760408593602060018580896080985f869c372086528181601f8601370191013760015afa1561013057510361012957602083918193720f3df6d732807ef1319fb7b8bb8522d0beac029082525afa1561012257510361011b5781548091038411610114575f84819482948284950190555af11561010d575f80f35b600a610157565b6009610157565b6008610157565b6007610157565b6006610157565b6005610157565b6004610157565b6003610157565b6002610157565b6001610157565b5f80fd5b5f5260205ffd"},"0x7e99c2f1731D3750b74A2a0623C1F1DcB8cCa45e":{"balance":"0xd3c21bcecceda1000000"},"0x87466A8266b9DFB3Dc9180a9c43946c4AB2c2cb2":{"balance":"0xd3c21bcecceda1000000"},"0x8849BAbdDcfC1327Ad199877861B577cEBd8A7b6":{"balance":"0xd3c21bcecceda1000000"},"0x99b832eb3F76ac3277b00beADC1e487C594ffb4c":{"balance":"0xd3c21bcecceda1000000"},"0x9b02c3e2df42533e0fd166798b5a616f59dbd2cc":{"balance":"0x0","code":"0x5f545f526004601cf3","storage":{"0x0000000000000000000000000000000000000000000000000000000000000000":"0x0000000000000000000000000000000000000000000000000000000000000014"}},"0xA310Df9740eb6CC2F5E41C59C87e339142834eA4":{"balance":"0xd3c21bcecceda1000000"},"0xD4EECE51cf451b60F59b271c5a748A8a9F16bC01":{"balance":"0xd3c21bcecceda1000000"},"0xE08643a1C4786b573d739625FD268732dBB3d033":{"balance":"0xd3c21bcecceda1000000"},"0xEE2722c39db6014Eacc5FBe43601136825b00977":{"balance":"0xd3c21bcecceda1000000"},"0xFB8Fb7f9bdc8951040a6D195764905138F7462Ed":{"balance":"0xd3c21bcecceda1000000"},"0xFd70Bef78778Ce8554e79D97521b69183960C574":{"balance":"0xd3c21bcecceda1000000"},"0xa24a79678c9fffEF3E9A1f3cb7e51f88F173B3D5":{"balance":"0xd3c21bcecceda1000000"},"0xa3659D39C901d5985450eE18a63B5b0811fDa521":{"balance":"0xd3c21bcecceda1000000"},"0xc201d4A5E6De676938533A0997802634E859e78b":{"balance":"0xd3c21bcecceda1000000"},"0xda1380825f827C6Ea92DFB547EF0a341Cbe21d77":{"balance":"0xd3c21bcecceda1000000"},"0xeDD5a9185F9F1C04a011117ad61564415057bf8F":{"balance":"0xd3c21bcecceda1000000"}},"coinbase":"0x0000000000000000000000000000000000000000","config":{"arrowGlacierBlock":0,"berlinBlock":0,"blobSchedule":{"cancun":{"baseFeeUpdateFraction":3338477,"max":0,"target":0},"prague":{"baseFeeUpdateFraction":5007716,"max":0,"target":0}},"byzantiumBlock":0,"cancunTime":0,"chainId":1789,"constantinopleBlock":0,"daoForkBlock":0,"daoForkSupport":true,"eip150Block":0,"eip155Block":0,"eip158Block":0,"graphGlacierBlock":0,"homesteadBlock":0,"istanbulBlock":0,"londonBlock":0,"mergeForkBlock":0,"mergeNetsplitBlock":0,"muirGlacierBlock":0,"petersburgBlock":0,"pragueTime":0,"shanghaiTime":0,"terminalTotalDifficulty":0,"terminalTotalDifficultyPassed":true},"difficulty":"0x0","extraData":"0x","gasLimit":"0x1c9c380","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","number":"0x0","timestamp":"0x684c5d2a"}
+{
+  "version": "1",
+  "engine": {
+    "Ethash": {}
+  },
+  "params": {
+    "eip150Transition": "0x0",
+    "eip160Transition": "0x0",
+    "eip161abcTransition": "0x0",
+    "eip161dTransition": "0x0",
+    "eip155Transition": "0x0",
+    "maxCodeSizeTransition": "0x0",
+    "maxCodeSize": "0x6000",
+    "maximumExtraDataSize": "0x20",
+    "eip140Transition": "0x0",
+    "eip211Transition": "0x0",
+    "eip214Transition": "0x0",
+    "eip658Transition": "0x0",
+    "eip145Transition": "0x0",
+    "eip1014Transition": "0x0",
+    "eip1052Transition": "0x0",
+    "eip1283Transition": "0x0",
+    "eip1283DisableTransition": "0x0",
+    "eip152Transition": "0x0",
+    "eip1108Transition": "0x0",
+    "eip1344Transition": "0x0",
+    "eip1884Transition": "0x0",
+    "eip2028Transition": "0x0",
+    "eip2200Transition": "0x0",
+    "eip2565Transition": "0x0",
+    "eip2718Transition": "0x0",
+    "eip2929Transition": "0x0",
+    "eip2930Transition": "0x0",
+    "eip1559Transition": "0x0",
+    "eip3238Transition": "0x0",
+    "eip3529Transition": "0x0",
+    "eip3541Transition": "0x0",
+    "eip3198Transition": "0x0",
+    "MergeForkIdTransition": "0x0",
+    "eip3651TransitionTimestamp": "0x0",
+    "eip3855TransitionTimestamp": "0x0",
+    "eip3860TransitionTimestamp": "0x0",
+    "eip4895TransitionTimestamp": "0x0",
+    "eip4844TransitionTimestamp": "0x0",
+    "eip4788TransitionTimestamp": "0x0",
+    "eip1153TransitionTimestamp": "0x0",
+    "eip5656TransitionTimestamp": "0x0",
+    "eip6780TransitionTimestamp": "0x0",
+    "eip2537TransitionTimestamp": "0x0",
+    "eip2935TransitionTimestamp": "0x0",
+    "eip6110TransitionTimestamp": "0x0",
+    "depositContractAddress": "0x00000000219ab540356cbb839cbe05303d7705fa",
+    "eip7002TransitionTimestamp": "0x0",
+    "eip7251TransitionTimestamp": "0x0",
+    "eip7702TransitionTimestamp": "0x0",
+    "eip7623TransitionTimestamp": "0x0",
+    "blobSchedule": {
+      "cancun": {
+        "baseFeeUpdateFraction": 3338477,
+        "max": 0,
+        "target": 0
+      },
+      "prague": {
+        "baseFeeUpdateFraction": 5007716,
+        "max": 0,
+        "target": 0
+      }
+    },
+    "networkID": "0x6fd",
+    "chainID": "0x6fd",
+    "terminalTotalDifficulty": "0x0"
+  },
+  "genesis": {
+    "seal": {
+      "ethereum": {
+        "nonce": "0x0000000000000000",
+        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    "difficulty": "0x0",
+    "author": "0x0000000000000000000000000000000000000000",
+    "timestamp": "0x684c5d2a",
+    "extraData": "0x",
+    "gasLimit": "0x1c9c380"
+  },
+  "accounts": {
+    "0x0000F90827F1C53a10cb7A02335B175320002935": {
+      "balance": "0x0",
+      "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500"
+    },
+    "0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02": {
+      "balance": "0x0",
+      "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"
+    },
+    "0x03e95Af0fC4971EdCa12E6d2d1540c28314d15d5": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x28f2d8ef4e0fe6B2E945cF5C33a0118a30a62354": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x33018A42499f10B54d9dBCeBB71831C805D64cE3": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x3492DA004098d728201fD82657f1207a6E5426bd": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x47fAE86F6416e6115a80635238AFd2F18D69926B": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x49eed2ac33f09e931bd660f0168417b9614485b6": {
+      "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "code": "0x346101535773ad9923c37370bcbcf00ed194506d8950848956965f9060209160c060e091610140946101609061018091609a9660e3360361014c575f359860203560f01c9360223560ea1c9860263560601c9a603a3599605a359b607a359a5f60db3560c01c9a03610145576004815f80739b02c3e2df42533e0fd166798b5a616f59dbd2cc5afa1561013e5751036101375760408593602060018580896080985f869c372086528181601f8601370191013760015afa1561013057510361012957602083918193720f3df6d732807ef1319fb7b8bb8522d0beac029082525afa1561012257510361011b5781548091038411610114575f84819482948284950190555af11561010d575f80f35b600a610157565b6009610157565b6008610157565b6007610157565b6006610157565b6005610157565b6004610157565b6003610157565b6002610157565b6001610157565b5f80fd5b5f5260205ffd"
+    },
+    "0x7e99c2f1731D3750b74A2a0623C1F1DcB8cCa45e": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x87466A8266b9DFB3Dc9180a9c43946c4AB2c2cb2": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x8849BAbdDcfC1327Ad199877861B577cEBd8A7b6": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x99b832eb3F76ac3277b00beADC1e487C594ffb4c": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x9b02c3e2df42533e0fd166798b5a616f59dbd2cc": {
+      "balance": "0x0",
+      "code": "0x5f545f526004601cf3",
+      "storage": {
+        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000014"
+      }
+    },
+    "0xA310Df9740eb6CC2F5E41C59C87e339142834eA4": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xD4EECE51cf451b60F59b271c5a748A8a9F16bC01": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xE08643a1C4786b573d739625FD268732dBB3d033": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xEE2722c39db6014Eacc5FBe43601136825b00977": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xFB8Fb7f9bdc8951040a6D195764905138F7462Ed": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xFd70Bef78778Ce8554e79D97521b69183960C574": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xa24a79678c9fffEF3E9A1f3cb7e51f88F173B3D5": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xa3659D39C901d5985450eE18a63B5b0811fDa521": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xc201d4A5E6De676938533A0997802634E859e78b": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xda1380825f827C6Ea92DFB547EF0a341Cbe21d77": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xeDD5a9185F9F1C04a011117ad61564415057bf8F": {
+      "balance": "0xd3c21bcecceda1000000"
+    }
+  }
+}

--- a/devnet/chain-specs/chain-spec-21.json
+++ b/devnet/chain-specs/chain-spec-21.json
@@ -1,1 +1,167 @@
-{"alloc":{"0x0000F90827F1C53a10cb7A02335B175320002935":{"balance":"0x0","code":"0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500"},"0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02":{"balance":"0x0","code":"0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"},"0x03e95Af0fC4971EdCa12E6d2d1540c28314d15d5":{"balance":"0xd3c21bcecceda1000000"},"0x28f2d8ef4e0fe6B2E945cF5C33a0118a30a62354":{"balance":"0xd3c21bcecceda1000000"},"0x33018A42499f10B54d9dBCeBB71831C805D64cE3":{"balance":"0xd3c21bcecceda1000000"},"0x3492DA004098d728201fD82657f1207a6E5426bd":{"balance":"0xd3c21bcecceda1000000"},"0x47fAE86F6416e6115a80635238AFd2F18D69926B":{"balance":"0xd3c21bcecceda1000000"},"0x49eed2ac33f09e931bd660f0168417b9614485b6":{"balance":"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","code":"0x346101535773ad9923c37370bcbcf00ed194506d8950848956965f9060209160c060e091610140946101609061018091609a9660e3360361014c575f359860203560f01c9360223560ea1c9860263560601c9a603a3599605a359b607a359a5f60db3560c01c9a03610145576004815f80739b02c3e2df42533e0fd166798b5a616f59dbd2cc5afa1561013e5751036101375760408593602060018580896080985f869c372086528181601f8601370191013760015afa1561013057510361012957602083918193720f3df6d732807ef1319fb7b8bb8522d0beac029082525afa1561012257510361011b5781548091038411610114575f84819482948284950190555af11561010d575f80f35b600a610157565b6009610157565b6008610157565b6007610157565b6006610157565b6005610157565b6004610157565b6003610157565b6002610157565b6001610157565b5f80fd5b5f5260205ffd"},"0x7e99c2f1731D3750b74A2a0623C1F1DcB8cCa45e":{"balance":"0xd3c21bcecceda1000000"},"0x87466A8266b9DFB3Dc9180a9c43946c4AB2c2cb2":{"balance":"0xd3c21bcecceda1000000"},"0x8849BAbdDcfC1327Ad199877861B577cEBd8A7b6":{"balance":"0xd3c21bcecceda1000000"},"0x99b832eb3F76ac3277b00beADC1e487C594ffb4c":{"balance":"0xd3c21bcecceda1000000"},"0x9b02c3e2df42533e0fd166798b5a616f59dbd2cc":{"balance":"0x0","code":"0x5f545f526004601cf3","storage":{"0x0000000000000000000000000000000000000000000000000000000000000000":"0x0000000000000000000000000000000000000000000000000000000000000015"}},"0xA310Df9740eb6CC2F5E41C59C87e339142834eA4":{"balance":"0xd3c21bcecceda1000000"},"0xD4EECE51cf451b60F59b271c5a748A8a9F16bC01":{"balance":"0xd3c21bcecceda1000000"},"0xE08643a1C4786b573d739625FD268732dBB3d033":{"balance":"0xd3c21bcecceda1000000"},"0xEE2722c39db6014Eacc5FBe43601136825b00977":{"balance":"0xd3c21bcecceda1000000"},"0xFB8Fb7f9bdc8951040a6D195764905138F7462Ed":{"balance":"0xd3c21bcecceda1000000"},"0xFd70Bef78778Ce8554e79D97521b69183960C574":{"balance":"0xd3c21bcecceda1000000"},"0xa24a79678c9fffEF3E9A1f3cb7e51f88F173B3D5":{"balance":"0xd3c21bcecceda1000000"},"0xa3659D39C901d5985450eE18a63B5b0811fDa521":{"balance":"0xd3c21bcecceda1000000"},"0xc201d4A5E6De676938533A0997802634E859e78b":{"balance":"0xd3c21bcecceda1000000"},"0xda1380825f827C6Ea92DFB547EF0a341Cbe21d77":{"balance":"0xd3c21bcecceda1000000"},"0xeDD5a9185F9F1C04a011117ad61564415057bf8F":{"balance":"0xd3c21bcecceda1000000"}},"coinbase":"0x0000000000000000000000000000000000000000","config":{"arrowGlacierBlock":0,"berlinBlock":0,"blobSchedule":{"cancun":{"baseFeeUpdateFraction":3338477,"max":0,"target":0},"prague":{"baseFeeUpdateFraction":5007716,"max":0,"target":0}},"byzantiumBlock":0,"cancunTime":0,"chainId":1790,"constantinopleBlock":0,"daoForkBlock":0,"daoForkSupport":true,"eip150Block":0,"eip155Block":0,"eip158Block":0,"graphGlacierBlock":0,"homesteadBlock":0,"istanbulBlock":0,"londonBlock":0,"mergeForkBlock":0,"mergeNetsplitBlock":0,"muirGlacierBlock":0,"petersburgBlock":0,"pragueTime":0,"shanghaiTime":0,"terminalTotalDifficulty":0,"terminalTotalDifficultyPassed":true},"difficulty":"0x0","extraData":"0x","gasLimit":"0x1c9c380","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","number":"0x0","timestamp":"0x684c5d2a"}
+{
+  "version": "1",
+  "engine": {
+    "Ethash": {}
+  },
+  "params": {
+    "eip150Transition": "0x0",
+    "eip160Transition": "0x0",
+    "eip161abcTransition": "0x0",
+    "eip161dTransition": "0x0",
+    "eip155Transition": "0x0",
+    "maxCodeSizeTransition": "0x0",
+    "maxCodeSize": "0x6000",
+    "maximumExtraDataSize": "0x20",
+    "eip140Transition": "0x0",
+    "eip211Transition": "0x0",
+    "eip214Transition": "0x0",
+    "depositContractAddress": "0x00000000219ab540356cbb839cbe05303d7705fa",
+    "eip658Transition": "0x0",
+    "eip145Transition": "0x0",
+    "eip1014Transition": "0x0",
+    "eip1052Transition": "0x0",
+    "eip1283Transition": "0x0",
+    "eip1283DisableTransition": "0x0",
+    "eip152Transition": "0x0",
+    "eip1108Transition": "0x0",
+    "eip1344Transition": "0x0",
+    "eip1884Transition": "0x0",
+    "eip2028Transition": "0x0",
+    "eip2200Transition": "0x0",
+    "eip2565Transition": "0x0",
+    "eip2718Transition": "0x0",
+    "eip2929Transition": "0x0",
+    "eip2930Transition": "0x0",
+    "eip1559Transition": "0x0",
+    "eip3238Transition": "0x0",
+    "eip3529Transition": "0x0",
+    "eip3541Transition": "0x0",
+    "eip3198Transition": "0x0",
+    "MergeForkIdTransition": "0x0",
+    "eip3651TransitionTimestamp": "0x0",
+    "eip3855TransitionTimestamp": "0x0",
+    "eip3860TransitionTimestamp": "0x0",
+    "eip4895TransitionTimestamp": "0x0",
+    "eip4844TransitionTimestamp": "0x0",
+    "eip4788TransitionTimestamp": "0x0",
+    "eip1153TransitionTimestamp": "0x0",
+    "eip5656TransitionTimestamp": "0x0",
+    "eip6780TransitionTimestamp": "0x0",
+    "eip2537TransitionTimestamp": "0x0",
+    "eip2935TransitionTimestamp": "0x0",
+    "eip6110TransitionTimestamp": "0x0",
+    "eip7002TransitionTimestamp": "0x0",
+    "eip7251TransitionTimestamp": "0x0",
+    "eip7702TransitionTimestamp": "0x0",
+    "eip7623TransitionTimestamp": "0x0",
+    "blobSchedule": {
+      "cancun": {
+        "baseFeeUpdateFraction": 3338477,
+        "max": 0,
+        "target": 0
+      },
+      "prague": {
+        "baseFeeUpdateFraction": 5007716,
+        "max": 0,
+        "target": 0
+      }
+    },
+    "networkID": "0x6fe",
+    "chainID": "0x6fe",
+    "terminalTotalDifficulty": "0x0"
+  },
+  "genesis": {
+    "seal": {
+      "ethereum": {
+        "nonce": "0x0000000000000000",
+        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    "difficulty": "0x0",
+    "author": "0x0000000000000000000000000000000000000000",
+    "timestamp": "0x684c5d2a",
+    "extraData": "0x",
+    "gasLimit": "0x1c9c380"
+  },
+  "accounts": {
+    "0x0000F90827F1C53a10cb7A02335B175320002935": {
+      "balance": "0x0",
+      "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500"
+    },
+    "0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02": {
+      "balance": "0x0",
+      "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"
+    },
+    "0x03e95Af0fC4971EdCa12E6d2d1540c28314d15d5": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x28f2d8ef4e0fe6B2E945cF5C33a0118a30a62354": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x33018A42499f10B54d9dBCeBB71831C805D64cE3": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x3492DA004098d728201fD82657f1207a6E5426bd": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x47fAE86F6416e6115a80635238AFd2F18D69926B": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x49eed2ac33f09e931bd660f0168417b9614485b6": {
+      "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "code": "0x346101535773ad9923c37370bcbcf00ed194506d8950848956965f9060209160c060e091610140946101609061018091609a9660e3360361014c575f359860203560f01c9360223560ea1c9860263560601c9a603a3599605a359b607a359a5f60db3560c01c9a03610145576004815f80739b02c3e2df42533e0fd166798b5a616f59dbd2cc5afa1561013e5751036101375760408593602060018580896080985f869c372086528181601f8601370191013760015afa1561013057510361012957602083918193720f3df6d732807ef1319fb7b8bb8522d0beac029082525afa1561012257510361011b5781548091038411610114575f84819482948284950190555af11561010d575f80f35b600a610157565b6009610157565b6008610157565b6007610157565b6006610157565b6005610157565b6004610157565b6003610157565b6002610157565b6001610157565b5f80fd5b5f5260205ffd"
+    },
+    "0x7e99c2f1731D3750b74A2a0623C1F1DcB8cCa45e": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x87466A8266b9DFB3Dc9180a9c43946c4AB2c2cb2": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x8849BAbdDcfC1327Ad199877861B577cEBd8A7b6": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x99b832eb3F76ac3277b00beADC1e487C594ffb4c": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x9b02c3e2df42533e0fd166798b5a616f59dbd2cc": {
+      "balance": "0x0",
+      "code": "0x5f545f526004601cf3",
+      "storage": {
+        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000015"
+      }
+    },
+    "0xA310Df9740eb6CC2F5E41C59C87e339142834eA4": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xD4EECE51cf451b60F59b271c5a748A8a9F16bC01": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xE08643a1C4786b573d739625FD268732dBB3d033": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xEE2722c39db6014Eacc5FBe43601136825b00977": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xFB8Fb7f9bdc8951040a6D195764905138F7462Ed": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xFd70Bef78778Ce8554e79D97521b69183960C574": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xa24a79678c9fffEF3E9A1f3cb7e51f88F173B3D5": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xa3659D39C901d5985450eE18a63B5b0811fDa521": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xc201d4A5E6De676938533A0997802634E859e78b": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xda1380825f827C6Ea92DFB547EF0a341Cbe21d77": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xeDD5a9185F9F1C04a011117ad61564415057bf8F": {
+      "balance": "0xd3c21bcecceda1000000"
+    }
+  }
+}

--- a/devnet/chain-specs/chain-spec-22.json
+++ b/devnet/chain-specs/chain-spec-22.json
@@ -1,1 +1,167 @@
-{"alloc":{"0x0000F90827F1C53a10cb7A02335B175320002935":{"balance":"0x0","code":"0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500"},"0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02":{"balance":"0x0","code":"0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"},"0x03e95Af0fC4971EdCa12E6d2d1540c28314d15d5":{"balance":"0xd3c21bcecceda1000000"},"0x28f2d8ef4e0fe6B2E945cF5C33a0118a30a62354":{"balance":"0xd3c21bcecceda1000000"},"0x33018A42499f10B54d9dBCeBB71831C805D64cE3":{"balance":"0xd3c21bcecceda1000000"},"0x3492DA004098d728201fD82657f1207a6E5426bd":{"balance":"0xd3c21bcecceda1000000"},"0x47fAE86F6416e6115a80635238AFd2F18D69926B":{"balance":"0xd3c21bcecceda1000000"},"0x49eed2ac33f09e931bd660f0168417b9614485b6":{"balance":"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","code":"0x346101535773ad9923c37370bcbcf00ed194506d8950848956965f9060209160c060e091610140946101609061018091609a9660e3360361014c575f359860203560f01c9360223560ea1c9860263560601c9a603a3599605a359b607a359a5f60db3560c01c9a03610145576004815f80739b02c3e2df42533e0fd166798b5a616f59dbd2cc5afa1561013e5751036101375760408593602060018580896080985f869c372086528181601f8601370191013760015afa1561013057510361012957602083918193720f3df6d732807ef1319fb7b8bb8522d0beac029082525afa1561012257510361011b5781548091038411610114575f84819482948284950190555af11561010d575f80f35b600a610157565b6009610157565b6008610157565b6007610157565b6006610157565b6005610157565b6004610157565b6003610157565b6002610157565b6001610157565b5f80fd5b5f5260205ffd"},"0x7e99c2f1731D3750b74A2a0623C1F1DcB8cCa45e":{"balance":"0xd3c21bcecceda1000000"},"0x87466A8266b9DFB3Dc9180a9c43946c4AB2c2cb2":{"balance":"0xd3c21bcecceda1000000"},"0x8849BAbdDcfC1327Ad199877861B577cEBd8A7b6":{"balance":"0xd3c21bcecceda1000000"},"0x99b832eb3F76ac3277b00beADC1e487C594ffb4c":{"balance":"0xd3c21bcecceda1000000"},"0x9b02c3e2df42533e0fd166798b5a616f59dbd2cc":{"balance":"0x0","code":"0x5f545f526004601cf3","storage":{"0x0000000000000000000000000000000000000000000000000000000000000000":"0x0000000000000000000000000000000000000000000000000000000000000016"}},"0xA310Df9740eb6CC2F5E41C59C87e339142834eA4":{"balance":"0xd3c21bcecceda1000000"},"0xD4EECE51cf451b60F59b271c5a748A8a9F16bC01":{"balance":"0xd3c21bcecceda1000000"},"0xE08643a1C4786b573d739625FD268732dBB3d033":{"balance":"0xd3c21bcecceda1000000"},"0xEE2722c39db6014Eacc5FBe43601136825b00977":{"balance":"0xd3c21bcecceda1000000"},"0xFB8Fb7f9bdc8951040a6D195764905138F7462Ed":{"balance":"0xd3c21bcecceda1000000"},"0xFd70Bef78778Ce8554e79D97521b69183960C574":{"balance":"0xd3c21bcecceda1000000"},"0xa24a79678c9fffEF3E9A1f3cb7e51f88F173B3D5":{"balance":"0xd3c21bcecceda1000000"},"0xa3659D39C901d5985450eE18a63B5b0811fDa521":{"balance":"0xd3c21bcecceda1000000"},"0xc201d4A5E6De676938533A0997802634E859e78b":{"balance":"0xd3c21bcecceda1000000"},"0xda1380825f827C6Ea92DFB547EF0a341Cbe21d77":{"balance":"0xd3c21bcecceda1000000"},"0xeDD5a9185F9F1C04a011117ad61564415057bf8F":{"balance":"0xd3c21bcecceda1000000"}},"coinbase":"0x0000000000000000000000000000000000000000","config":{"arrowGlacierBlock":0,"berlinBlock":0,"blobSchedule":{"cancun":{"baseFeeUpdateFraction":3338477,"max":0,"target":0},"prague":{"baseFeeUpdateFraction":5007716,"max":0,"target":0}},"byzantiumBlock":0,"cancunTime":0,"chainId":1791,"constantinopleBlock":0,"daoForkBlock":0,"daoForkSupport":true,"eip150Block":0,"eip155Block":0,"eip158Block":0,"graphGlacierBlock":0,"homesteadBlock":0,"istanbulBlock":0,"londonBlock":0,"mergeForkBlock":0,"mergeNetsplitBlock":0,"muirGlacierBlock":0,"petersburgBlock":0,"pragueTime":0,"shanghaiTime":0,"terminalTotalDifficulty":0,"terminalTotalDifficultyPassed":true},"difficulty":"0x0","extraData":"0x","gasLimit":"0x1c9c380","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","number":"0x0","timestamp":"0x684c5d2a"}
+{
+  "version": "1",
+  "engine": {
+    "Ethash": {}
+  },
+  "params": {
+    "eip150Transition": "0x0",
+    "eip160Transition": "0x0",
+    "eip161abcTransition": "0x0",
+    "eip161dTransition": "0x0",
+    "eip155Transition": "0x0",
+    "maxCodeSizeTransition": "0x0",
+    "maxCodeSize": "0x6000",
+    "maximumExtraDataSize": "0x20",
+    "eip140Transition": "0x0",
+    "eip211Transition": "0x0",
+    "eip214Transition": "0x0",
+    "eip658Transition": "0x0",
+    "eip145Transition": "0x0",
+    "eip1014Transition": "0x0",
+    "eip1052Transition": "0x0",
+    "eip1283Transition": "0x0",
+    "eip1283DisableTransition": "0x0",
+    "depositContractAddress": "0x00000000219ab540356cbb839cbe05303d7705fa",
+    "eip152Transition": "0x0",
+    "eip1108Transition": "0x0",
+    "eip1344Transition": "0x0",
+    "eip1884Transition": "0x0",
+    "eip2028Transition": "0x0",
+    "eip2200Transition": "0x0",
+    "eip2565Transition": "0x0",
+    "eip2718Transition": "0x0",
+    "eip2929Transition": "0x0",
+    "eip2930Transition": "0x0",
+    "eip1559Transition": "0x0",
+    "eip3238Transition": "0x0",
+    "eip3529Transition": "0x0",
+    "eip3541Transition": "0x0",
+    "eip3198Transition": "0x0",
+    "MergeForkIdTransition": "0x0",
+    "eip3651TransitionTimestamp": "0x0",
+    "eip3855TransitionTimestamp": "0x0",
+    "eip3860TransitionTimestamp": "0x0",
+    "eip4895TransitionTimestamp": "0x0",
+    "eip4844TransitionTimestamp": "0x0",
+    "eip4788TransitionTimestamp": "0x0",
+    "eip1153TransitionTimestamp": "0x0",
+    "eip5656TransitionTimestamp": "0x0",
+    "eip6780TransitionTimestamp": "0x0",
+    "eip2537TransitionTimestamp": "0x0",
+    "eip2935TransitionTimestamp": "0x0",
+    "eip6110TransitionTimestamp": "0x0",
+    "eip7002TransitionTimestamp": "0x0",
+    "eip7251TransitionTimestamp": "0x0",
+    "eip7702TransitionTimestamp": "0x0",
+    "eip7623TransitionTimestamp": "0x0",
+    "blobSchedule": {
+      "cancun": {
+        "baseFeeUpdateFraction": 3338477,
+        "max": 0,
+        "target": 0
+      },
+      "prague": {
+        "baseFeeUpdateFraction": 5007716,
+        "max": 0,
+        "target": 0
+      }
+    },
+    "networkID": "0x6ff",
+    "chainID": "0x6ff",
+    "terminalTotalDifficulty": "0x0"
+  },
+  "genesis": {
+    "seal": {
+      "ethereum": {
+        "nonce": "0x0000000000000000",
+        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    "difficulty": "0x0",
+    "author": "0x0000000000000000000000000000000000000000",
+    "timestamp": "0x684c5d2a",
+    "extraData": "0x",
+    "gasLimit": "0x1c9c380"
+  },
+  "accounts": {
+    "0x0000F90827F1C53a10cb7A02335B175320002935": {
+      "balance": "0x0",
+      "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500"
+    },
+    "0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02": {
+      "balance": "0x0",
+      "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"
+    },
+    "0x03e95Af0fC4971EdCa12E6d2d1540c28314d15d5": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x28f2d8ef4e0fe6B2E945cF5C33a0118a30a62354": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x33018A42499f10B54d9dBCeBB71831C805D64cE3": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x3492DA004098d728201fD82657f1207a6E5426bd": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x47fAE86F6416e6115a80635238AFd2F18D69926B": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x49eed2ac33f09e931bd660f0168417b9614485b6": {
+      "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "code": "0x346101535773ad9923c37370bcbcf00ed194506d8950848956965f9060209160c060e091610140946101609061018091609a9660e3360361014c575f359860203560f01c9360223560ea1c9860263560601c9a603a3599605a359b607a359a5f60db3560c01c9a03610145576004815f80739b02c3e2df42533e0fd166798b5a616f59dbd2cc5afa1561013e5751036101375760408593602060018580896080985f869c372086528181601f8601370191013760015afa1561013057510361012957602083918193720f3df6d732807ef1319fb7b8bb8522d0beac029082525afa1561012257510361011b5781548091038411610114575f84819482948284950190555af11561010d575f80f35b600a610157565b6009610157565b6008610157565b6007610157565b6006610157565b6005610157565b6004610157565b6003610157565b6002610157565b6001610157565b5f80fd5b5f5260205ffd"
+    },
+    "0x7e99c2f1731D3750b74A2a0623C1F1DcB8cCa45e": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x87466A8266b9DFB3Dc9180a9c43946c4AB2c2cb2": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x8849BAbdDcfC1327Ad199877861B577cEBd8A7b6": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x99b832eb3F76ac3277b00beADC1e487C594ffb4c": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x9b02c3e2df42533e0fd166798b5a616f59dbd2cc": {
+      "balance": "0x0",
+      "code": "0x5f545f526004601cf3",
+      "storage": {
+        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000016"
+      }
+    },
+    "0xA310Df9740eb6CC2F5E41C59C87e339142834eA4": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xD4EECE51cf451b60F59b271c5a748A8a9F16bC01": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xE08643a1C4786b573d739625FD268732dBB3d033": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xEE2722c39db6014Eacc5FBe43601136825b00977": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xFB8Fb7f9bdc8951040a6D195764905138F7462Ed": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xFd70Bef78778Ce8554e79D97521b69183960C574": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xa24a79678c9fffEF3E9A1f3cb7e51f88F173B3D5": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xa3659D39C901d5985450eE18a63B5b0811fDa521": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xc201d4A5E6De676938533A0997802634E859e78b": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xda1380825f827C6Ea92DFB547EF0a341Cbe21d77": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xeDD5a9185F9F1C04a011117ad61564415057bf8F": {
+      "balance": "0xd3c21bcecceda1000000"
+    }
+  }
+}

--- a/devnet/chain-specs/chain-spec-23.json
+++ b/devnet/chain-specs/chain-spec-23.json
@@ -1,1 +1,167 @@
-{"alloc":{"0x0000F90827F1C53a10cb7A02335B175320002935":{"balance":"0x0","code":"0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500"},"0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02":{"balance":"0x0","code":"0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"},"0x03e95Af0fC4971EdCa12E6d2d1540c28314d15d5":{"balance":"0xd3c21bcecceda1000000"},"0x28f2d8ef4e0fe6B2E945cF5C33a0118a30a62354":{"balance":"0xd3c21bcecceda1000000"},"0x33018A42499f10B54d9dBCeBB71831C805D64cE3":{"balance":"0xd3c21bcecceda1000000"},"0x3492DA004098d728201fD82657f1207a6E5426bd":{"balance":"0xd3c21bcecceda1000000"},"0x47fAE86F6416e6115a80635238AFd2F18D69926B":{"balance":"0xd3c21bcecceda1000000"},"0x49eed2ac33f09e931bd660f0168417b9614485b6":{"balance":"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","code":"0x346101535773ad9923c37370bcbcf00ed194506d8950848956965f9060209160c060e091610140946101609061018091609a9660e3360361014c575f359860203560f01c9360223560ea1c9860263560601c9a603a3599605a359b607a359a5f60db3560c01c9a03610145576004815f80739b02c3e2df42533e0fd166798b5a616f59dbd2cc5afa1561013e5751036101375760408593602060018580896080985f869c372086528181601f8601370191013760015afa1561013057510361012957602083918193720f3df6d732807ef1319fb7b8bb8522d0beac029082525afa1561012257510361011b5781548091038411610114575f84819482948284950190555af11561010d575f80f35b600a610157565b6009610157565b6008610157565b6007610157565b6006610157565b6005610157565b6004610157565b6003610157565b6002610157565b6001610157565b5f80fd5b5f5260205ffd"},"0x7e99c2f1731D3750b74A2a0623C1F1DcB8cCa45e":{"balance":"0xd3c21bcecceda1000000"},"0x87466A8266b9DFB3Dc9180a9c43946c4AB2c2cb2":{"balance":"0xd3c21bcecceda1000000"},"0x8849BAbdDcfC1327Ad199877861B577cEBd8A7b6":{"balance":"0xd3c21bcecceda1000000"},"0x99b832eb3F76ac3277b00beADC1e487C594ffb4c":{"balance":"0xd3c21bcecceda1000000"},"0x9b02c3e2df42533e0fd166798b5a616f59dbd2cc":{"balance":"0x0","code":"0x5f545f526004601cf3","storage":{"0x0000000000000000000000000000000000000000000000000000000000000000":"0x0000000000000000000000000000000000000000000000000000000000000017"}},"0xA310Df9740eb6CC2F5E41C59C87e339142834eA4":{"balance":"0xd3c21bcecceda1000000"},"0xD4EECE51cf451b60F59b271c5a748A8a9F16bC01":{"balance":"0xd3c21bcecceda1000000"},"0xE08643a1C4786b573d739625FD268732dBB3d033":{"balance":"0xd3c21bcecceda1000000"},"0xEE2722c39db6014Eacc5FBe43601136825b00977":{"balance":"0xd3c21bcecceda1000000"},"0xFB8Fb7f9bdc8951040a6D195764905138F7462Ed":{"balance":"0xd3c21bcecceda1000000"},"0xFd70Bef78778Ce8554e79D97521b69183960C574":{"balance":"0xd3c21bcecceda1000000"},"0xa24a79678c9fffEF3E9A1f3cb7e51f88F173B3D5":{"balance":"0xd3c21bcecceda1000000"},"0xa3659D39C901d5985450eE18a63B5b0811fDa521":{"balance":"0xd3c21bcecceda1000000"},"0xc201d4A5E6De676938533A0997802634E859e78b":{"balance":"0xd3c21bcecceda1000000"},"0xda1380825f827C6Ea92DFB547EF0a341Cbe21d77":{"balance":"0xd3c21bcecceda1000000"},"0xeDD5a9185F9F1C04a011117ad61564415057bf8F":{"balance":"0xd3c21bcecceda1000000"}},"coinbase":"0x0000000000000000000000000000000000000000","config":{"arrowGlacierBlock":0,"berlinBlock":0,"blobSchedule":{"cancun":{"baseFeeUpdateFraction":3338477,"max":0,"target":0},"prague":{"baseFeeUpdateFraction":5007716,"max":0,"target":0}},"byzantiumBlock":0,"cancunTime":0,"chainId":1792,"constantinopleBlock":0,"daoForkBlock":0,"daoForkSupport":true,"eip150Block":0,"eip155Block":0,"eip158Block":0,"graphGlacierBlock":0,"homesteadBlock":0,"istanbulBlock":0,"londonBlock":0,"mergeForkBlock":0,"mergeNetsplitBlock":0,"muirGlacierBlock":0,"petersburgBlock":0,"pragueTime":0,"shanghaiTime":0,"terminalTotalDifficulty":0,"terminalTotalDifficultyPassed":true},"difficulty":"0x0","extraData":"0x","gasLimit":"0x1c9c380","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","number":"0x0","timestamp":"0x684c5d2a"}
+{
+  "version": "1",
+  "engine": {
+    "Ethash": {}
+  },
+  "params": {
+    "eip150Transition": "0x0",
+    "eip160Transition": "0x0",
+    "eip161abcTransition": "0x0",
+    "eip161dTransition": "0x0",
+    "eip155Transition": "0x0",
+    "maxCodeSizeTransition": "0x0",
+    "maxCodeSize": "0x6000",
+    "maximumExtraDataSize": "0x20",
+    "eip140Transition": "0x0",
+    "eip211Transition": "0x0",
+    "eip214Transition": "0x0",
+    "eip658Transition": "0x0",
+    "eip145Transition": "0x0",
+    "eip1014Transition": "0x0",
+    "eip1052Transition": "0x0",
+    "eip1283Transition": "0x0",
+    "eip1283DisableTransition": "0x0",
+    "depositContractAddress": "0x00000000219ab540356cbb839cbe05303d7705fa",
+    "eip152Transition": "0x0",
+    "eip1108Transition": "0x0",
+    "eip1344Transition": "0x0",
+    "eip1884Transition": "0x0",
+    "eip2028Transition": "0x0",
+    "eip2200Transition": "0x0",
+    "eip2565Transition": "0x0",
+    "eip2718Transition": "0x0",
+    "eip2929Transition": "0x0",
+    "eip2930Transition": "0x0",
+    "eip1559Transition": "0x0",
+    "eip3238Transition": "0x0",
+    "eip3529Transition": "0x0",
+    "eip3541Transition": "0x0",
+    "eip3198Transition": "0x0",
+    "MergeForkIdTransition": "0x0",
+    "eip3651TransitionTimestamp": "0x0",
+    "eip3855TransitionTimestamp": "0x0",
+    "eip3860TransitionTimestamp": "0x0",
+    "eip4895TransitionTimestamp": "0x0",
+    "eip4844TransitionTimestamp": "0x0",
+    "eip4788TransitionTimestamp": "0x0",
+    "eip1153TransitionTimestamp": "0x0",
+    "eip5656TransitionTimestamp": "0x0",
+    "eip6780TransitionTimestamp": "0x0",
+    "eip2537TransitionTimestamp": "0x0",
+    "eip2935TransitionTimestamp": "0x0",
+    "eip6110TransitionTimestamp": "0x0",
+    "eip7002TransitionTimestamp": "0x0",
+    "eip7251TransitionTimestamp": "0x0",
+    "eip7702TransitionTimestamp": "0x0",
+    "eip7623TransitionTimestamp": "0x0",
+    "blobSchedule": {
+      "cancun": {
+        "baseFeeUpdateFraction": 3338477,
+        "max": 0,
+        "target": 0
+      },
+      "prague": {
+        "baseFeeUpdateFraction": 5007716,
+        "max": 0,
+        "target": 0
+      }
+    },
+    "networkID": "0x700",
+    "chainID": "0x700",
+    "terminalTotalDifficulty": "0x0"
+  },
+  "genesis": {
+    "seal": {
+      "ethereum": {
+        "nonce": "0x0000000000000000",
+        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    "difficulty": "0x0",
+    "author": "0x0000000000000000000000000000000000000000",
+    "timestamp": "0x684c5d2a",
+    "extraData": "0x",
+    "gasLimit": "0x1c9c380"
+  },
+  "accounts": {
+    "0x0000F90827F1C53a10cb7A02335B175320002935": {
+      "balance": "0x0",
+      "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500"
+    },
+    "0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02": {
+      "balance": "0x0",
+      "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"
+    },
+    "0x03e95Af0fC4971EdCa12E6d2d1540c28314d15d5": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x28f2d8ef4e0fe6B2E945cF5C33a0118a30a62354": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x33018A42499f10B54d9dBCeBB71831C805D64cE3": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x3492DA004098d728201fD82657f1207a6E5426bd": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x47fAE86F6416e6115a80635238AFd2F18D69926B": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x49eed2ac33f09e931bd660f0168417b9614485b6": {
+      "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "code": "0x346101535773ad9923c37370bcbcf00ed194506d8950848956965f9060209160c060e091610140946101609061018091609a9660e3360361014c575f359860203560f01c9360223560ea1c9860263560601c9a603a3599605a359b607a359a5f60db3560c01c9a03610145576004815f80739b02c3e2df42533e0fd166798b5a616f59dbd2cc5afa1561013e5751036101375760408593602060018580896080985f869c372086528181601f8601370191013760015afa1561013057510361012957602083918193720f3df6d732807ef1319fb7b8bb8522d0beac029082525afa1561012257510361011b5781548091038411610114575f84819482948284950190555af11561010d575f80f35b600a610157565b6009610157565b6008610157565b6007610157565b6006610157565b6005610157565b6004610157565b6003610157565b6002610157565b6001610157565b5f80fd5b5f5260205ffd"
+    },
+    "0x7e99c2f1731D3750b74A2a0623C1F1DcB8cCa45e": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x87466A8266b9DFB3Dc9180a9c43946c4AB2c2cb2": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x8849BAbdDcfC1327Ad199877861B577cEBd8A7b6": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x99b832eb3F76ac3277b00beADC1e487C594ffb4c": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x9b02c3e2df42533e0fd166798b5a616f59dbd2cc": {
+      "balance": "0x0",
+      "code": "0x5f545f526004601cf3",
+      "storage": {
+        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000017"
+      }
+    },
+    "0xA310Df9740eb6CC2F5E41C59C87e339142834eA4": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xD4EECE51cf451b60F59b271c5a748A8a9F16bC01": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xE08643a1C4786b573d739625FD268732dBB3d033": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xEE2722c39db6014Eacc5FBe43601136825b00977": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xFB8Fb7f9bdc8951040a6D195764905138F7462Ed": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xFd70Bef78778Ce8554e79D97521b69183960C574": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xa24a79678c9fffEF3E9A1f3cb7e51f88F173B3D5": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xa3659D39C901d5985450eE18a63B5b0811fDa521": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xc201d4A5E6De676938533A0997802634E859e78b": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xda1380825f827C6Ea92DFB547EF0a341Cbe21d77": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xeDD5a9185F9F1C04a011117ad61564415057bf8F": {
+      "balance": "0xd3c21bcecceda1000000"
+    }
+  }
+}

--- a/devnet/chain-specs/chain-spec-24.json
+++ b/devnet/chain-specs/chain-spec-24.json
@@ -1,1 +1,167 @@
-{"alloc":{"0x0000F90827F1C53a10cb7A02335B175320002935":{"balance":"0x0","code":"0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500"},"0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02":{"balance":"0x0","code":"0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"},"0x03e95Af0fC4971EdCa12E6d2d1540c28314d15d5":{"balance":"0xd3c21bcecceda1000000"},"0x28f2d8ef4e0fe6B2E945cF5C33a0118a30a62354":{"balance":"0xd3c21bcecceda1000000"},"0x33018A42499f10B54d9dBCeBB71831C805D64cE3":{"balance":"0xd3c21bcecceda1000000"},"0x3492DA004098d728201fD82657f1207a6E5426bd":{"balance":"0xd3c21bcecceda1000000"},"0x47fAE86F6416e6115a80635238AFd2F18D69926B":{"balance":"0xd3c21bcecceda1000000"},"0x49eed2ac33f09e931bd660f0168417b9614485b6":{"balance":"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","code":"0x346101535773ad9923c37370bcbcf00ed194506d8950848956965f9060209160c060e091610140946101609061018091609a9660e3360361014c575f359860203560f01c9360223560ea1c9860263560601c9a603a3599605a359b607a359a5f60db3560c01c9a03610145576004815f80739b02c3e2df42533e0fd166798b5a616f59dbd2cc5afa1561013e5751036101375760408593602060018580896080985f869c372086528181601f8601370191013760015afa1561013057510361012957602083918193720f3df6d732807ef1319fb7b8bb8522d0beac029082525afa1561012257510361011b5781548091038411610114575f84819482948284950190555af11561010d575f80f35b600a610157565b6009610157565b6008610157565b6007610157565b6006610157565b6005610157565b6004610157565b6003610157565b6002610157565b6001610157565b5f80fd5b5f5260205ffd"},"0x7e99c2f1731D3750b74A2a0623C1F1DcB8cCa45e":{"balance":"0xd3c21bcecceda1000000"},"0x87466A8266b9DFB3Dc9180a9c43946c4AB2c2cb2":{"balance":"0xd3c21bcecceda1000000"},"0x8849BAbdDcfC1327Ad199877861B577cEBd8A7b6":{"balance":"0xd3c21bcecceda1000000"},"0x99b832eb3F76ac3277b00beADC1e487C594ffb4c":{"balance":"0xd3c21bcecceda1000000"},"0x9b02c3e2df42533e0fd166798b5a616f59dbd2cc":{"balance":"0x0","code":"0x5f545f526004601cf3","storage":{"0x0000000000000000000000000000000000000000000000000000000000000000":"0x0000000000000000000000000000000000000000000000000000000000000018"}},"0xA310Df9740eb6CC2F5E41C59C87e339142834eA4":{"balance":"0xd3c21bcecceda1000000"},"0xD4EECE51cf451b60F59b271c5a748A8a9F16bC01":{"balance":"0xd3c21bcecceda1000000"},"0xE08643a1C4786b573d739625FD268732dBB3d033":{"balance":"0xd3c21bcecceda1000000"},"0xEE2722c39db6014Eacc5FBe43601136825b00977":{"balance":"0xd3c21bcecceda1000000"},"0xFB8Fb7f9bdc8951040a6D195764905138F7462Ed":{"balance":"0xd3c21bcecceda1000000"},"0xFd70Bef78778Ce8554e79D97521b69183960C574":{"balance":"0xd3c21bcecceda1000000"},"0xa24a79678c9fffEF3E9A1f3cb7e51f88F173B3D5":{"balance":"0xd3c21bcecceda1000000"},"0xa3659D39C901d5985450eE18a63B5b0811fDa521":{"balance":"0xd3c21bcecceda1000000"},"0xc201d4A5E6De676938533A0997802634E859e78b":{"balance":"0xd3c21bcecceda1000000"},"0xda1380825f827C6Ea92DFB547EF0a341Cbe21d77":{"balance":"0xd3c21bcecceda1000000"},"0xeDD5a9185F9F1C04a011117ad61564415057bf8F":{"balance":"0xd3c21bcecceda1000000"}},"coinbase":"0x0000000000000000000000000000000000000000","config":{"arrowGlacierBlock":0,"berlinBlock":0,"blobSchedule":{"cancun":{"baseFeeUpdateFraction":3338477,"max":0,"target":0},"prague":{"baseFeeUpdateFraction":5007716,"max":0,"target":0}},"byzantiumBlock":0,"cancunTime":0,"chainId":1793,"constantinopleBlock":0,"daoForkBlock":0,"daoForkSupport":true,"eip150Block":0,"eip155Block":0,"eip158Block":0,"graphGlacierBlock":0,"homesteadBlock":0,"istanbulBlock":0,"londonBlock":0,"mergeForkBlock":0,"mergeNetsplitBlock":0,"muirGlacierBlock":0,"petersburgBlock":0,"pragueTime":0,"shanghaiTime":0,"terminalTotalDifficulty":0,"terminalTotalDifficultyPassed":true},"difficulty":"0x0","extraData":"0x","gasLimit":"0x1c9c380","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0","number":"0x0","timestamp":"0x684c5d2a"}
+{
+  "version": "1",
+  "engine": {
+    "Ethash": {}
+  },
+  "params": {
+    "eip150Transition": "0x0",
+    "eip160Transition": "0x0",
+    "eip161abcTransition": "0x0",
+    "eip161dTransition": "0x0",
+    "eip155Transition": "0x0",
+    "maxCodeSizeTransition": "0x0",
+    "maxCodeSize": "0x6000",
+    "maximumExtraDataSize": "0x20",
+    "eip140Transition": "0x0",
+    "eip211Transition": "0x0",
+    "eip214Transition": "0x0",
+    "eip658Transition": "0x0",
+    "eip145Transition": "0x0",
+    "eip1014Transition": "0x0",
+    "eip1052Transition": "0x0",
+    "eip1283Transition": "0x0",
+    "eip1283DisableTransition": "0x0",
+    "eip152Transition": "0x0",
+    "eip1108Transition": "0x0",
+    "eip1344Transition": "0x0",
+    "eip1884Transition": "0x0",
+    "depositContractAddress": "0x00000000219ab540356cbb839cbe05303d7705fa",
+    "eip2028Transition": "0x0",
+    "eip2200Transition": "0x0",
+    "eip2565Transition": "0x0",
+    "eip2718Transition": "0x0",
+    "eip2929Transition": "0x0",
+    "eip2930Transition": "0x0",
+    "eip1559Transition": "0x0",
+    "eip3238Transition": "0x0",
+    "eip3529Transition": "0x0",
+    "eip3541Transition": "0x0",
+    "eip3198Transition": "0x0",
+    "MergeForkIdTransition": "0x0",
+    "eip3651TransitionTimestamp": "0x0",
+    "eip3855TransitionTimestamp": "0x0",
+    "eip3860TransitionTimestamp": "0x0",
+    "eip4895TransitionTimestamp": "0x0",
+    "eip4844TransitionTimestamp": "0x0",
+    "eip4788TransitionTimestamp": "0x0",
+    "eip1153TransitionTimestamp": "0x0",
+    "eip5656TransitionTimestamp": "0x0",
+    "eip6780TransitionTimestamp": "0x0",
+    "eip2537TransitionTimestamp": "0x0",
+    "eip2935TransitionTimestamp": "0x0",
+    "eip6110TransitionTimestamp": "0x0",
+    "eip7002TransitionTimestamp": "0x0",
+    "eip7251TransitionTimestamp": "0x0",
+    "eip7702TransitionTimestamp": "0x0",
+    "eip7623TransitionTimestamp": "0x0",
+    "blobSchedule": {
+      "cancun": {
+        "baseFeeUpdateFraction": 3338477,
+        "max": 0,
+        "target": 0
+      },
+      "prague": {
+        "baseFeeUpdateFraction": 5007716,
+        "max": 0,
+        "target": 0
+      }
+    },
+    "networkID": "0x701",
+    "chainID": "0x701",
+    "terminalTotalDifficulty": "0x0"
+  },
+  "genesis": {
+    "seal": {
+      "ethereum": {
+        "nonce": "0x0000000000000000",
+        "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    "difficulty": "0x0",
+    "author": "0x0000000000000000000000000000000000000000",
+    "timestamp": "0x684c5d2a",
+    "extraData": "0x",
+    "gasLimit": "0x1c9c380"
+  },
+  "accounts": {
+    "0x0000F90827F1C53a10cb7A02335B175320002935": {
+      "balance": "0x0",
+      "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500"
+    },
+    "0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02": {
+      "balance": "0x0",
+      "code": "0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500"
+    },
+    "0x03e95Af0fC4971EdCa12E6d2d1540c28314d15d5": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x28f2d8ef4e0fe6B2E945cF5C33a0118a30a62354": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x33018A42499f10B54d9dBCeBB71831C805D64cE3": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x3492DA004098d728201fD82657f1207a6E5426bd": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x47fAE86F6416e6115a80635238AFd2F18D69926B": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x49eed2ac33f09e931bd660f0168417b9614485b6": {
+      "balance": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "code": "0x346101535773ad9923c37370bcbcf00ed194506d8950848956965f9060209160c060e091610140946101609061018091609a9660e3360361014c575f359860203560f01c9360223560ea1c9860263560601c9a603a3599605a359b607a359a5f60db3560c01c9a03610145576004815f80739b02c3e2df42533e0fd166798b5a616f59dbd2cc5afa1561013e5751036101375760408593602060018580896080985f869c372086528181601f8601370191013760015afa1561013057510361012957602083918193720f3df6d732807ef1319fb7b8bb8522d0beac029082525afa1561012257510361011b5781548091038411610114575f84819482948284950190555af11561010d575f80f35b600a610157565b6009610157565b6008610157565b6007610157565b6006610157565b6005610157565b6004610157565b6003610157565b6002610157565b6001610157565b5f80fd5b5f5260205ffd"
+    },
+    "0x7e99c2f1731D3750b74A2a0623C1F1DcB8cCa45e": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x87466A8266b9DFB3Dc9180a9c43946c4AB2c2cb2": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x8849BAbdDcfC1327Ad199877861B577cEBd8A7b6": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x99b832eb3F76ac3277b00beADC1e487C594ffb4c": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0x9b02c3e2df42533e0fd166798b5a616f59dbd2cc": {
+      "balance": "0x0",
+      "code": "0x5f545f526004601cf3",
+      "storage": {
+        "0x0000000000000000000000000000000000000000000000000000000000000000": "0x0000000000000000000000000000000000000000000000000000000000000018"
+      }
+    },
+    "0xA310Df9740eb6CC2F5E41C59C87e339142834eA4": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xD4EECE51cf451b60F59b271c5a748A8a9F16bC01": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xE08643a1C4786b573d739625FD268732dBB3d033": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xEE2722c39db6014Eacc5FBe43601136825b00977": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xFB8Fb7f9bdc8951040a6D195764905138F7462Ed": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xFd70Bef78778Ce8554e79D97521b69183960C574": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xa24a79678c9fffEF3E9A1f3cb7e51f88F173B3D5": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xa3659D39C901d5985450eE18a63B5b0811fDa521": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xc201d4A5E6De676938533A0997802634E859e78b": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xda1380825f827C6Ea92DFB547EF0a341Cbe21d77": {
+      "balance": "0xd3c21bcecceda1000000"
+    },
+    "0xeDD5a9185F9F1C04a011117ad61564415057bf8F": {
+      "balance": "0xd3c21bcecceda1000000"
+    }
+  }
+}

--- a/devnet/docker-compose.yaml
+++ b/devnet/docker-compose.yaml
@@ -150,32 +150,21 @@ services:
             bootnode-evm-init-20:
                 condition: service_completed_successfully
         entrypoint:
-        - /app/kadena-reth
-        - node
-        - --datadir=/root/ethereum
-        - --chain=/config/chain-spec.json
-        - --metrics=0.0.0.0:9001
-        - --log.file.directory=/root/logs
-        - --addr=0.0.0.0
-        - --port=30323
-        - --authrpc.jwtsecret=/run/secrets/jwtsecret
-        - --authrpc.addr=0.0.0.0
-        - --authrpc.port=8551
-        - --http
-        - --http.addr=0.0.0.0
-        - --http.port=8545
-        - --http.api=eth,net,web3,admin,debug,trace,txpool,rpc,reth,ots
-        - --ws
-        - --ws.addr=0.0.0.0
-        - --ws.port=8546
-        - --ws.api=eth,net,web3,admin,debug,trace,txpool,rpc,reth,ots
-        - --disable-nat
-        - --nat=none
-        - --disable-dns-discovery
-        - --discovery.port=30323
-        - --engine.persistence-threshold=0
-        - --engine.memory-block-buffer-target=0
-        - --p2p-secret-key=/run/secrets/p2p-secret
+        - /nethermind/nethermind
+        - --config=none
+        - --data-dir=/root/ethereum/.nethermind
+        - --init-chainspecpath=/config/chain-spec.json
+        - --network-p2pport=30323
+        - --init-discoveryenabled=true
+        - --network-discoveryport=30323
+        - --jsonrpc-enabled=true
+        - --jsonrpc-host=bootnode-evm-20
+        - --jsonrpc-enginehost=bootnode-evm-20
+        - --jsonrpc-engineport=8551
+        - --jsonrpc-enabledmodules=[eth,net,web3,admin,debug,trace,txpool,personal]
+        - --init-websocketsenabled=true
+        - --jsonrpc-websocketsport=8546
+        - --jsonrpc-jwtsecretfile=/run/secrets/jwtsecret
         expose:
         - '8545'
         - '8546'
@@ -184,7 +173,7 @@ services:
         - 30323/tcp
         - 30323/udp
         hostname: bootnode-evm-20
-        image: ${RETH_IMAGE:-ghcr.io/kadena-io/kadena-reth:sha-eff370d}
+        image: ${NETHERMIND_IMAGE:-nethermind/nethermind:1.32.3}
         networks:
             bootnode-internal: null
             p2p: null
@@ -214,32 +203,21 @@ services:
             bootnode-evm-init-21:
                 condition: service_completed_successfully
         entrypoint:
-        - /app/kadena-reth
-        - node
-        - --datadir=/root/ethereum
-        - --chain=/config/chain-spec.json
-        - --metrics=0.0.0.0:9001
-        - --log.file.directory=/root/logs
-        - --addr=0.0.0.0
-        - --port=30324
-        - --authrpc.jwtsecret=/run/secrets/jwtsecret
-        - --authrpc.addr=0.0.0.0
-        - --authrpc.port=8551
-        - --http
-        - --http.addr=0.0.0.0
-        - --http.port=8545
-        - --http.api=eth,net,web3,admin,debug,trace,txpool,rpc,reth,ots
-        - --ws
-        - --ws.addr=0.0.0.0
-        - --ws.port=8546
-        - --ws.api=eth,net,web3,admin,debug,trace,txpool,rpc,reth,ots
-        - --disable-nat
-        - --nat=none
-        - --disable-dns-discovery
-        - --discovery.port=30324
-        - --engine.persistence-threshold=0
-        - --engine.memory-block-buffer-target=0
-        - --p2p-secret-key=/run/secrets/p2p-secret
+        - /nethermind/nethermind
+        - --config=none
+        - --data-dir=/root/ethereum/.nethermind
+        - --init-chainspecpath=/config/chain-spec.json
+        - --network-p2pport=30324
+        - --init-discoveryenabled=true
+        - --network-discoveryport=30324
+        - --jsonrpc-enabled=true
+        - --jsonrpc-host=bootnode-evm-21
+        - --jsonrpc-enginehost=bootnode-evm-21
+        - --jsonrpc-engineport=8551
+        - --jsonrpc-enabledmodules=[eth,net,web3,admin,debug,trace,txpool,personal]
+        - --init-websocketsenabled=true
+        - --jsonrpc-websocketsport=8546
+        - --jsonrpc-jwtsecretfile=/run/secrets/jwtsecret
         expose:
         - '8545'
         - '8546'
@@ -248,7 +226,7 @@ services:
         - 30324/tcp
         - 30324/udp
         hostname: bootnode-evm-21
-        image: ${RETH_IMAGE:-ghcr.io/kadena-io/kadena-reth:sha-eff370d}
+        image: ${NETHERMIND_IMAGE:-nethermind/nethermind:1.32.3}
         networks:
             bootnode-internal: null
             p2p: null
@@ -278,32 +256,21 @@ services:
             bootnode-evm-init-22:
                 condition: service_completed_successfully
         entrypoint:
-        - /app/kadena-reth
-        - node
-        - --datadir=/root/ethereum
-        - --chain=/config/chain-spec.json
-        - --metrics=0.0.0.0:9001
-        - --log.file.directory=/root/logs
-        - --addr=0.0.0.0
-        - --port=30325
-        - --authrpc.jwtsecret=/run/secrets/jwtsecret
-        - --authrpc.addr=0.0.0.0
-        - --authrpc.port=8551
-        - --http
-        - --http.addr=0.0.0.0
-        - --http.port=8545
-        - --http.api=eth,net,web3,admin,debug,trace,txpool,rpc,reth,ots
-        - --ws
-        - --ws.addr=0.0.0.0
-        - --ws.port=8546
-        - --ws.api=eth,net,web3,admin,debug,trace,txpool,rpc,reth,ots
-        - --disable-nat
-        - --nat=none
-        - --disable-dns-discovery
-        - --discovery.port=30325
-        - --engine.persistence-threshold=0
-        - --engine.memory-block-buffer-target=0
-        - --p2p-secret-key=/run/secrets/p2p-secret
+        - /nethermind/nethermind
+        - --config=none
+        - --data-dir=/root/ethereum/.nethermind
+        - --init-chainspecpath=/config/chain-spec.json
+        - --network-p2pport=30325
+        - --init-discoveryenabled=true
+        - --network-discoveryport=30325
+        - --jsonrpc-enabled=true
+        - --jsonrpc-host=bootnode-evm-22
+        - --jsonrpc-enginehost=bootnode-evm-22
+        - --jsonrpc-engineport=8551
+        - --jsonrpc-enabledmodules=[eth,net,web3,admin,debug,trace,txpool,personal]
+        - --init-websocketsenabled=true
+        - --jsonrpc-websocketsport=8546
+        - --jsonrpc-jwtsecretfile=/run/secrets/jwtsecret
         expose:
         - '8545'
         - '8546'
@@ -312,7 +279,7 @@ services:
         - 30325/tcp
         - 30325/udp
         hostname: bootnode-evm-22
-        image: ${RETH_IMAGE:-ghcr.io/kadena-io/kadena-reth:sha-eff370d}
+        image: ${NETHERMIND_IMAGE:-nethermind/nethermind:1.32.3}
         networks:
             bootnode-internal: null
             p2p: null
@@ -342,32 +309,21 @@ services:
             bootnode-evm-init-23:
                 condition: service_completed_successfully
         entrypoint:
-        - /app/kadena-reth
-        - node
-        - --datadir=/root/ethereum
-        - --chain=/config/chain-spec.json
-        - --metrics=0.0.0.0:9001
-        - --log.file.directory=/root/logs
-        - --addr=0.0.0.0
-        - --port=30326
-        - --authrpc.jwtsecret=/run/secrets/jwtsecret
-        - --authrpc.addr=0.0.0.0
-        - --authrpc.port=8551
-        - --http
-        - --http.addr=0.0.0.0
-        - --http.port=8545
-        - --http.api=eth,net,web3,admin,debug,trace,txpool,rpc,reth,ots
-        - --ws
-        - --ws.addr=0.0.0.0
-        - --ws.port=8546
-        - --ws.api=eth,net,web3,admin,debug,trace,txpool,rpc,reth,ots
-        - --disable-nat
-        - --nat=none
-        - --disable-dns-discovery
-        - --discovery.port=30326
-        - --engine.persistence-threshold=0
-        - --engine.memory-block-buffer-target=0
-        - --p2p-secret-key=/run/secrets/p2p-secret
+        - /nethermind/nethermind
+        - --config=none
+        - --data-dir=/root/ethereum/.nethermind
+        - --init-chainspecpath=/config/chain-spec.json
+        - --network-p2pport=30326
+        - --init-discoveryenabled=true
+        - --network-discoveryport=30326
+        - --jsonrpc-enabled=true
+        - --jsonrpc-host=bootnode-evm-23
+        - --jsonrpc-enginehost=bootnode-evm-23
+        - --jsonrpc-engineport=8551
+        - --jsonrpc-enabledmodules=[eth,net,web3,admin,debug,trace,txpool,personal]
+        - --init-websocketsenabled=true
+        - --jsonrpc-websocketsport=8546
+        - --jsonrpc-jwtsecretfile=/run/secrets/jwtsecret
         expose:
         - '8545'
         - '8546'
@@ -376,7 +332,7 @@ services:
         - 30326/tcp
         - 30326/udp
         hostname: bootnode-evm-23
-        image: ${RETH_IMAGE:-ghcr.io/kadena-io/kadena-reth:sha-eff370d}
+        image: ${NETHERMIND_IMAGE:-nethermind/nethermind:1.32.3}
         networks:
             bootnode-internal: null
             p2p: null
@@ -406,32 +362,21 @@ services:
             bootnode-evm-init-24:
                 condition: service_completed_successfully
         entrypoint:
-        - /app/kadena-reth
-        - node
-        - --datadir=/root/ethereum
-        - --chain=/config/chain-spec.json
-        - --metrics=0.0.0.0:9001
-        - --log.file.directory=/root/logs
-        - --addr=0.0.0.0
-        - --port=30327
-        - --authrpc.jwtsecret=/run/secrets/jwtsecret
-        - --authrpc.addr=0.0.0.0
-        - --authrpc.port=8551
-        - --http
-        - --http.addr=0.0.0.0
-        - --http.port=8545
-        - --http.api=eth,net,web3,admin,debug,trace,txpool,rpc,reth,ots
-        - --ws
-        - --ws.addr=0.0.0.0
-        - --ws.port=8546
-        - --ws.api=eth,net,web3,admin,debug,trace,txpool,rpc,reth,ots
-        - --disable-nat
-        - --nat=none
-        - --disable-dns-discovery
-        - --discovery.port=30327
-        - --engine.persistence-threshold=0
-        - --engine.memory-block-buffer-target=0
-        - --p2p-secret-key=/run/secrets/p2p-secret
+        - /nethermind/nethermind
+        - --config=none
+        - --data-dir=/root/ethereum/.nethermind
+        - --init-chainspecpath=/config/chain-spec.json
+        - --network-p2pport=30327
+        - --init-discoveryenabled=true
+        - --network-discoveryport=30327
+        - --jsonrpc-enabled=true
+        - --jsonrpc-host=bootnode-evm-24
+        - --jsonrpc-enginehost=bootnode-evm-24
+        - --jsonrpc-engineport=8551
+        - --jsonrpc-enabledmodules=[eth,net,web3,admin,debug,trace,txpool,personal]
+        - --init-websocketsenabled=true
+        - --jsonrpc-websocketsport=8546
+        - --jsonrpc-jwtsecretfile=/run/secrets/jwtsecret
         expose:
         - '8545'
         - '8546'
@@ -440,7 +385,7 @@ services:
         - 30327/tcp
         - 30327/udp
         hostname: bootnode-evm-24
-        image: ${RETH_IMAGE:-ghcr.io/kadena-io/kadena-reth:sha-eff370d}
+        image: ${NETHERMIND_IMAGE:-nethermind/nethermind:1.32.3}
         networks:
             bootnode-internal: null
             p2p: null
@@ -472,7 +417,7 @@ services:
         - /bin/sh
         - -c
         hostname: bootnode-evm-init-20
-        image: ${RETH_IMAGE:-ghcr.io/kadena-io/kadena-reth:sha-eff370d}
+        image: ${NETHDERMIND_IMAGE:-nethermind/nethermind:1.32.3}
         networks:
             bootnode-internal: null
         restart: 'no'
@@ -495,7 +440,7 @@ services:
         - /bin/sh
         - -c
         hostname: bootnode-evm-init-21
-        image: ${RETH_IMAGE:-ghcr.io/kadena-io/kadena-reth:sha-eff370d}
+        image: ${NETHDERMIND_IMAGE:-nethermind/nethermind:1.32.3}
         networks:
             bootnode-internal: null
         restart: 'no'
@@ -518,7 +463,7 @@ services:
         - /bin/sh
         - -c
         hostname: bootnode-evm-init-22
-        image: ${RETH_IMAGE:-ghcr.io/kadena-io/kadena-reth:sha-eff370d}
+        image: ${NETHDERMIND_IMAGE:-nethermind/nethermind:1.32.3}
         networks:
             bootnode-internal: null
         restart: 'no'
@@ -541,7 +486,7 @@ services:
         - /bin/sh
         - -c
         hostname: bootnode-evm-init-23
-        image: ${RETH_IMAGE:-ghcr.io/kadena-io/kadena-reth:sha-eff370d}
+        image: ${NETHDERMIND_IMAGE:-nethermind/nethermind:1.32.3}
         networks:
             bootnode-internal: null
         restart: 'no'
@@ -564,7 +509,7 @@ services:
         - /bin/sh
         - -c
         hostname: bootnode-evm-init-24
-        image: ${RETH_IMAGE:-ghcr.io/kadena-io/kadena-reth:sha-eff370d}
+        image: ${NETHDERMIND_IMAGE:-nethermind/nethermind:1.32.3}
         networks:
             bootnode-internal: null
         restart: 'no'


### PR DESCRIPTION
This pull request integrates the Nethermind EVM alongside the existing Geth and Reth implementations. The integration requires handling differences in the chain spec format and command line arguments specific to Nethermind.

### Changes
Chain Spec Translation: The chain spec file has been translated using the [jq script](https://github.com/NethermindEth/core-scripts/tree/release/1.32.2/gen2spec).
Command Line Adjustments: Adjustments have been made to accommodate the different command line arguments required by Nethermind.

### Issues

- Node Block Production: While nodes produce blocks, some are failing intermittently. Further investigation may be required to address potential underlying issues.
- Startup Time: Nodes exhibit slower startup times, causing connection timeouts and subsequent failures. In some cases, the nodes were successfully recovered by restarting the EVM nodes.

### Additional Configuration

Manual Addition: The 
```
"depositContractAddress": "0x00000000219ab540356cbb839cbe05303d7705fa"
``` 
must be added manually to the chain spec file.
